### PR TITLE
Making CHaMP and BRAT CRB programs private

### DIFF
--- a/Programs/BRAT_CRB/Program.xml
+++ b/Programs/BRAT_CRB/Program.xml
@@ -6,7 +6,7 @@
 
   <MetaData>
     <Meta name="projectFile">project.rs.xml</Meta>
-    <Meta name="access">PUBLIC</Meta>
+    <Meta name="access">PRIVATE</Meta>
     <Meta name="apiUrl">https://iz2u8e5df2.execute-api.us-west-2.amazonaws.com/prod/api</Meta>
     <Meta name="projectXSDs">http://xml.riverscapes.xyz/Projects/XSD/V1</Meta>
   </MetaData>

--- a/Programs/CHaMP/Program.xml
+++ b/Programs/CHaMP/Program.xml
@@ -6,7 +6,7 @@
 
   <MetaData>
     <Meta name="projectFile">project.rs.xml</Meta>
-    <Meta name="access">PUBLIC</Meta>
+    <Meta name="access">PRIVATE</Meta>
     <Meta name="apiUrl">https://iz2u8e5df2.execute-api.us-west-2.amazonaws.com/prod/api</Meta>
     <Meta name="projectXSDs">http://xml.riverscapes.xyz/Projects/XSD/V1</Meta>
   </MetaData>


### PR DESCRIPTION
@MattReimer this pull request simply makes the CHaMP and BRAT CRB programs private. CHaMP is an incomplete dataset and so we don't want everyone accessing it and getting the false impression that it is finished. BRAT CRB is for Chris Jordan at NOAA and any BRAT results are unvalidated and not for public consumption.