### PR TITLE
Making changes to Perennial NHD & adding Watershed Boundaries 

### DIFF
--- a/Symbology/qgis/RSContext/wbdhu10.qml
+++ b/Symbology/qgis/RSContext/wbdhu10.qml
@@ -1,0 +1,461 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis simplifyDrawingHints="1" version="3.12.1-București" labelsEnabled="1" simplifyMaxScale="1" simplifyLocal="1" readOnly="0" maxScale="0" simplifyAlgorithm="0" simplifyDrawingTol="1" styleCategories="AllStyleCategories" minScale="100000000" hasScaleBasedVisibilityFlag="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+    <symbols>
+      <symbol name="0" type="fill" clip_to_extent="1" force_rhr="0" alpha="1">
+        <layer enabled="1" locked="0" class="SimpleFill" pass="0">
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="190,207,80,0" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="1.5" k="outline_width"/>
+          <prop v="Pixel" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style fontItalic="0" fontWordSpacing="0" namedStyle="Regular" fontCapitals="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" multilineHeight="1" fontSize="8" isExpression="1" fontKerning="1" fieldName="Name +  '\n'  +  &quot;HUC10&quot; " textOrientation="horizontal" fontUnderline="0" fontStrikeout="0" useSubstitutions="0" fontSizeUnit="Point" fontFamily="MS Shell Dlg 2" textOpacity="1" textColor="0,0,0,255" fontWeight="50" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0">
+        <text-buffer bufferColor="255,255,255,255" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="128" bufferOpacity="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferSizeUnits="MM"/>
+        <text-mask maskEnabled="0" maskType="0" maskJoinStyle="128" maskSize="1.5" maskSizeUnits="MM" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1"/>
+        <background shapeBorderColor="128,128,128,255" shapeBlendMode="0" shapeOffsetUnit="MM" shapeBorderWidthUnit="MM" shapeType="0" shapeDraw="0" shapeSVGFile="" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeSizeUnit="MM" shapeRotation="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeJoinStyle="64" shapeOpacity="1" shapeRotationType="0" shapeRadiiUnit="MM" shapeOffsetY="0" shapeOffsetX="0" shapeFillColor="255,255,255,255" shapeSizeX="0" shapeSizeType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0">
+          <symbol name="markerSymbol" type="marker" clip_to_extent="1" force_rhr="0" alpha="1">
+            <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
+              <prop v="0" k="angle"/>
+              <prop v="255,158,23,255" k="color"/>
+              <prop v="1" k="horizontal_anchor_point"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="circle" k="name"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="35,35,35,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0" k="outline_width"/>
+              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="diameter" k="scale_method"/>
+              <prop v="2" k="size"/>
+              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+              <prop v="MM" k="size_unit"/>
+              <prop v="1" k="vertical_anchor_point"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowOpacity="0.7" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowOffsetAngle="135" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetDist="1" shadowUnder="0" shadowRadiusUnit="MM" shadowOffsetUnit="MM" shadowOffsetGlobal="1" shadowBlendMode="6" shadowDraw="0"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </dd_properties>
+        <substitutions/>
+      </text-style>
+      <text-format autoWrapLength="0" addDirectionSymbol="0" decimals="3" useMaxLineLengthForAutoWrap="1" multilineAlign="1" formatNumbers="0" wrapChar="" rightDirectionSymbol=">" placeDirectionSymbol="0" leftDirectionSymbol="&lt;" reverseDirectionSymbol="0" plussign="0"/>
+      <placement xOffset="0" overrunDistance="0" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" priority="5" geometryGenerator="" repeatDistanceUnits="MM" geometryGeneratorEnabled="0" distUnits="MM" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" fitInPolygonOnly="0" placementFlags="10" preserveRotation="1" centroidInside="0" overrunDistanceUnit="MM" layerType="PolygonGeometry" dist="0" placement="0" maxCurvedCharAngleOut="-25" offsetUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" rotationAngle="0" quadOffset="4" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" centroidWhole="0"/>
+      <rendering obstacleFactor="1" obstacle="1" minFeatureSize="0" labelPerPart="0" drawLabels="1" zIndex="0" displayAll="0" scaleMin="0" fontMaxPixelSize="10000" obstacleType="1" maxNumLabels="2000" limitNumLabels="0" mergeLines="0" scaleVisibility="0" upsidedownLabels="0" scaleMax="0" fontLimitPixelSize="0" fontMinPixelSize="3"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option name="name" value="" type="QString"/>
+          <Option name="properties"/>
+          <Option name="type" value="collection" type="QString"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+          <Option name="ddProperties" type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+          <Option name="drawToAllParts" value="false" type="bool"/>
+          <Option name="enabled" value="1" type="QString"/>
+          <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot; alpha=&quot;1&quot;>&lt;layer enabled=&quot;1&quot; locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+          <Option name="minLength" value="0" type="double"/>
+          <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="minLengthUnit" value="MM" type="QString"/>
+          <Option name="offsetFromAnchor" value="0" type="double"/>
+          <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+          <Option name="offsetFromLabel" value="0" type="double"/>
+          <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
+  <customproperties>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+    <DiagramCategory sizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" diagramOrientation="Up" showAxis="1" direction="0" labelPlacementMethod="XHeight" minimumSize="0" height="15" maxScaleDenominator="1e+08" width="15" spacingUnitScale="3x:0,0,0,0,0,0" scaleDependency="Area" lineSizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" penAlpha="255" spacingUnit="MM" backgroundAlpha="255" barWidth="5" backgroundColor="#ffffff" penWidth="0" rotationOffset="270" enabled="0" spacing="5" opacity="1" scaleBasedVisibility="0" sizeType="MM" penColor="#000000">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute field="" label="" color="#000000"/>
+      <axisSymbol>
+        <symbol name="" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
+          <layer enabled="1" locked="0" class="SimpleLine" pass="0">
+            <prop v="square" k="capstyle"/>
+            <prop v="5;2" k="customdash"/>
+            <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+            <prop v="MM" k="customdash_unit"/>
+            <prop v="0" k="draw_inside_polygon"/>
+            <prop v="bevel" k="joinstyle"/>
+            <prop v="35,35,35,255" k="line_color"/>
+            <prop v="solid" k="line_style"/>
+            <prop v="0.26" k="line_width"/>
+            <prop v="MM" k="line_width_unit"/>
+            <prop v="0" k="offset"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="0" k="ring_filter"/>
+            <prop v="0" k="use_custom_dash"/>
+            <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </axisSymbol>
+    </DiagramCategory>
+  </SingleCategoryDiagramRenderer>
+  <DiagramLayerSettings obstacle="0" placement="1" zIndex="0" linePlacementFlags="18" dist="0" showAll="1" priority="0">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration type="Map">
+      <Option name="QgsGeometryGapCheck" type="Map">
+        <Option name="allowedGapsBuffer" value="0" type="double"/>
+        <Option name="allowedGapsEnabled" value="false" type="bool"/>
+        <Option name="allowedGapsLayer" value="" type="QString"/>
+      </Option>
+    </checkConfiguration>
+  </geometryOptions>
+  <referencedLayers/>
+  <referencingLayers/>
+  <fieldConfiguration>
+    <field name="TNMID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="MetaSource">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceData">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceOrig">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceFeat">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="LoadDate">
+      <editWidget type="DateTime">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="AreaSqKm">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="AreaAcres">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="GNIS_ID">
+      <editWidget type="Range">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="States">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="HUC10">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="HUType">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="HUMod">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Shape_Leng">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Shape_Area">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="TNMID" name="" index="0"/>
+    <alias field="MetaSource" name="" index="1"/>
+    <alias field="SourceData" name="" index="2"/>
+    <alias field="SourceOrig" name="" index="3"/>
+    <alias field="SourceFeat" name="" index="4"/>
+    <alias field="LoadDate" name="" index="5"/>
+    <alias field="AreaSqKm" name="" index="6"/>
+    <alias field="AreaAcres" name="" index="7"/>
+    <alias field="GNIS_ID" name="" index="8"/>
+    <alias field="Name" name="" index="9"/>
+    <alias field="States" name="" index="10"/>
+    <alias field="HUC10" name="" index="11"/>
+    <alias field="HUType" name="" index="12"/>
+    <alias field="HUMod" name="" index="13"/>
+    <alias field="Shape_Leng" name="" index="14"/>
+    <alias field="Shape_Area" name="" index="15"/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default field="TNMID" expression="" applyOnUpdate="0"/>
+    <default field="MetaSource" expression="" applyOnUpdate="0"/>
+    <default field="SourceData" expression="" applyOnUpdate="0"/>
+    <default field="SourceOrig" expression="" applyOnUpdate="0"/>
+    <default field="SourceFeat" expression="" applyOnUpdate="0"/>
+    <default field="LoadDate" expression="" applyOnUpdate="0"/>
+    <default field="AreaSqKm" expression="" applyOnUpdate="0"/>
+    <default field="AreaAcres" expression="" applyOnUpdate="0"/>
+    <default field="GNIS_ID" expression="" applyOnUpdate="0"/>
+    <default field="Name" expression="" applyOnUpdate="0"/>
+    <default field="States" expression="" applyOnUpdate="0"/>
+    <default field="HUC10" expression="" applyOnUpdate="0"/>
+    <default field="HUType" expression="" applyOnUpdate="0"/>
+    <default field="HUMod" expression="" applyOnUpdate="0"/>
+    <default field="Shape_Leng" expression="" applyOnUpdate="0"/>
+    <default field="Shape_Area" expression="" applyOnUpdate="0"/>
+  </defaults>
+  <constraints>
+    <constraint field="TNMID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="MetaSource" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceData" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceOrig" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceFeat" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="LoadDate" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="AreaSqKm" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="AreaAcres" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="GNIS_ID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Name" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="States" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="HUC10" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="HUType" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="HUMod" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Shape_Leng" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Shape_Area" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint field="TNMID" exp="" desc=""/>
+    <constraint field="MetaSource" exp="" desc=""/>
+    <constraint field="SourceData" exp="" desc=""/>
+    <constraint field="SourceOrig" exp="" desc=""/>
+    <constraint field="SourceFeat" exp="" desc=""/>
+    <constraint field="LoadDate" exp="" desc=""/>
+    <constraint field="AreaSqKm" exp="" desc=""/>
+    <constraint field="AreaAcres" exp="" desc=""/>
+    <constraint field="GNIS_ID" exp="" desc=""/>
+    <constraint field="Name" exp="" desc=""/>
+    <constraint field="States" exp="" desc=""/>
+    <constraint field="HUC10" exp="" desc=""/>
+    <constraint field="HUType" exp="" desc=""/>
+    <constraint field="HUMod" exp="" desc=""/>
+    <constraint field="Shape_Leng" exp="" desc=""/>
+    <constraint field="Shape_Area" exp="" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+    <columns>
+      <column name="TNMID" type="field" hidden="0" width="-1"/>
+      <column name="MetaSource" type="field" hidden="0" width="-1"/>
+      <column name="SourceData" type="field" hidden="0" width="-1"/>
+      <column name="SourceOrig" type="field" hidden="0" width="-1"/>
+      <column name="SourceFeat" type="field" hidden="0" width="-1"/>
+      <column name="LoadDate" type="field" hidden="0" width="-1"/>
+      <column name="AreaSqKm" type="field" hidden="0" width="-1"/>
+      <column name="AreaAcres" type="field" hidden="0" width="-1"/>
+      <column name="GNIS_ID" type="field" hidden="0" width="-1"/>
+      <column name="Name" type="field" hidden="0" width="-1"/>
+      <column name="States" type="field" hidden="0" width="-1"/>
+      <column name="HUC10" type="field" hidden="0" width="-1"/>
+      <column name="HUType" type="field" hidden="0" width="-1"/>
+      <column name="HUMod" type="field" hidden="0" width="-1"/>
+      <column name="Shape_Leng" type="field" hidden="0" width="-1"/>
+      <column name="Shape_Area" type="field" hidden="0" width="-1"/>
+      <column type="actions" hidden="1" width="-1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <storedexpressions/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>generatedlayout</editorlayout>
+  <editable>
+    <field name="AreaAcres" editable="1"/>
+    <field name="AreaSqKm" editable="1"/>
+    <field name="GNIS_ID" editable="1"/>
+    <field name="HUC10" editable="1"/>
+    <field name="HUMod" editable="1"/>
+    <field name="HUType" editable="1"/>
+    <field name="LoadDate" editable="1"/>
+    <field name="MetaSource" editable="1"/>
+    <field name="Name" editable="1"/>
+    <field name="Shape_Area" editable="1"/>
+    <field name="Shape_Leng" editable="1"/>
+    <field name="SourceData" editable="1"/>
+    <field name="SourceFeat" editable="1"/>
+    <field name="SourceOrig" editable="1"/>
+    <field name="States" editable="1"/>
+    <field name="TNMID" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="AreaAcres" labelOnTop="0"/>
+    <field name="AreaSqKm" labelOnTop="0"/>
+    <field name="GNIS_ID" labelOnTop="0"/>
+    <field name="HUC10" labelOnTop="0"/>
+    <field name="HUMod" labelOnTop="0"/>
+    <field name="HUType" labelOnTop="0"/>
+    <field name="LoadDate" labelOnTop="0"/>
+    <field name="MetaSource" labelOnTop="0"/>
+    <field name="Name" labelOnTop="0"/>
+    <field name="Shape_Area" labelOnTop="0"/>
+    <field name="Shape_Leng" labelOnTop="0"/>
+    <field name="SourceData" labelOnTop="0"/>
+    <field name="SourceFeat" labelOnTop="0"/>
+    <field name="SourceOrig" labelOnTop="0"/>
+    <field name="States" labelOnTop="0"/>
+    <field name="TNMID" labelOnTop="0"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>Name</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/Symbology/qgis/RSContext/wbdhu12.qml
+++ b/Symbology/qgis/RSContext/wbdhu12.qml
@@ -1,0 +1,532 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis simplifyDrawingHints="1" version="3.12.1-București" labelsEnabled="1" simplifyMaxScale="1" simplifyLocal="1" readOnly="0" maxScale="0" simplifyAlgorithm="0" simplifyDrawingTol="1" styleCategories="AllStyleCategories" minScale="100000000" hasScaleBasedVisibilityFlag="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+    <symbols>
+      <symbol name="0" type="fill" clip_to_extent="1" force_rhr="0" alpha="1">
+        <layer enabled="1" locked="0" class="SimpleFill" pass="0">
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="190,207,80,0" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="227,26,28,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.9" k="outline_width"/>
+          <prop v="Pixel" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style fontItalic="0" fontWordSpacing="0" namedStyle="Regular" fontCapitals="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" multilineHeight="1" fontSize="7" isExpression="1" fontKerning="1" fieldName=" &quot;Name&quot;  +  '\n'  +  &quot;HUC12&quot; " textOrientation="horizontal" fontUnderline="0" fontStrikeout="0" useSubstitutions="0" fontSizeUnit="Point" fontFamily="MS Shell Dlg 2" textOpacity="1" textColor="65,65,65,255" fontWeight="50" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0">
+        <text-buffer bufferColor="255,255,255,255" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="128" bufferOpacity="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferSizeUnits="MM"/>
+        <text-mask maskEnabled="0" maskType="0" maskJoinStyle="128" maskSize="1.5" maskSizeUnits="MM" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1"/>
+        <background shapeBorderColor="128,128,128,255" shapeBlendMode="0" shapeOffsetUnit="MM" shapeBorderWidthUnit="MM" shapeType="0" shapeDraw="0" shapeSVGFile="" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeSizeUnit="MM" shapeRotation="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeJoinStyle="64" shapeOpacity="1" shapeRotationType="0" shapeRadiiUnit="MM" shapeOffsetY="0" shapeOffsetX="0" shapeFillColor="255,255,255,255" shapeSizeX="0" shapeSizeType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0">
+          <symbol name="markerSymbol" type="marker" clip_to_extent="1" force_rhr="0" alpha="1">
+            <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
+              <prop v="0" k="angle"/>
+              <prop v="255,158,23,255" k="color"/>
+              <prop v="1" k="horizontal_anchor_point"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="circle" k="name"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="35,35,35,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0" k="outline_width"/>
+              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="diameter" k="scale_method"/>
+              <prop v="2" k="size"/>
+              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+              <prop v="MM" k="size_unit"/>
+              <prop v="1" k="vertical_anchor_point"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowOpacity="0.7" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowOffsetAngle="135" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetDist="1" shadowUnder="0" shadowRadiusUnit="MM" shadowOffsetUnit="MM" shadowOffsetGlobal="1" shadowBlendMode="6" shadowDraw="1"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </dd_properties>
+        <substitutions/>
+      </text-style>
+      <text-format autoWrapLength="0" addDirectionSymbol="0" decimals="3" useMaxLineLengthForAutoWrap="1" multilineAlign="1" formatNumbers="0" wrapChar="" rightDirectionSymbol=">" placeDirectionSymbol="0" leftDirectionSymbol="&lt;" reverseDirectionSymbol="0" plussign="0"/>
+      <placement xOffset="0" overrunDistance="0" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" priority="5" geometryGenerator="" repeatDistanceUnits="MM" geometryGeneratorEnabled="0" distUnits="MM" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" fitInPolygonOnly="0" placementFlags="10" preserveRotation="1" centroidInside="0" overrunDistanceUnit="MM" layerType="PolygonGeometry" dist="0" placement="0" maxCurvedCharAngleOut="-25" offsetUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" rotationAngle="0" quadOffset="4" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" centroidWhole="0"/>
+      <rendering obstacleFactor="1" obstacle="1" minFeatureSize="0" labelPerPart="0" drawLabels="1" zIndex="0" displayAll="0" scaleMin="0" fontMaxPixelSize="10000" obstacleType="1" maxNumLabels="2000" limitNumLabels="0" mergeLines="0" scaleVisibility="0" upsidedownLabels="0" scaleMax="0" fontLimitPixelSize="0" fontMinPixelSize="3"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option name="name" value="" type="QString"/>
+          <Option name="properties"/>
+          <Option name="type" value="collection" type="QString"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+          <Option name="ddProperties" type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+          <Option name="drawToAllParts" value="false" type="bool"/>
+          <Option name="enabled" value="1" type="QString"/>
+          <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot; alpha=&quot;1&quot;>&lt;layer enabled=&quot;1&quot; locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+          <Option name="minLength" value="0" type="double"/>
+          <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="minLengthUnit" value="MM" type="QString"/>
+          <Option name="offsetFromAnchor" value="0" type="double"/>
+          <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+          <Option name="offsetFromLabel" value="0" type="double"/>
+          <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
+  <customproperties>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+    <DiagramCategory sizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" diagramOrientation="Up" showAxis="1" direction="0" labelPlacementMethod="XHeight" minimumSize="0" height="15" maxScaleDenominator="1e+08" width="15" spacingUnitScale="3x:0,0,0,0,0,0" scaleDependency="Area" lineSizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" penAlpha="255" spacingUnit="MM" backgroundAlpha="255" barWidth="5" backgroundColor="#ffffff" penWidth="0" rotationOffset="270" enabled="0" spacing="5" opacity="1" scaleBasedVisibility="0" sizeType="MM" penColor="#000000">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <axisSymbol>
+        <symbol name="" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
+          <layer enabled="1" locked="0" class="SimpleLine" pass="0">
+            <prop v="square" k="capstyle"/>
+            <prop v="5;2" k="customdash"/>
+            <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+            <prop v="MM" k="customdash_unit"/>
+            <prop v="0" k="draw_inside_polygon"/>
+            <prop v="bevel" k="joinstyle"/>
+            <prop v="35,35,35,255" k="line_color"/>
+            <prop v="solid" k="line_style"/>
+            <prop v="0.26" k="line_width"/>
+            <prop v="MM" k="line_width_unit"/>
+            <prop v="0" k="offset"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="0" k="ring_filter"/>
+            <prop v="0" k="use_custom_dash"/>
+            <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </axisSymbol>
+    </DiagramCategory>
+  </SingleCategoryDiagramRenderer>
+  <DiagramLayerSettings obstacle="0" placement="1" zIndex="0" linePlacementFlags="18" dist="0" showAll="1" priority="0">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration type="Map">
+      <Option name="QgsGeometryGapCheck" type="Map">
+        <Option name="allowedGapsBuffer" value="0" type="double"/>
+        <Option name="allowedGapsEnabled" value="false" type="bool"/>
+        <Option name="allowedGapsLayer" value="" type="QString"/>
+      </Option>
+    </checkConfiguration>
+  </geometryOptions>
+  <referencedLayers/>
+  <referencingLayers/>
+  <fieldConfiguration>
+    <field name="TNMID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="MetaSource">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceData">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceOrig">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceFeat">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="LoadDate">
+      <editWidget type="DateTime">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="NonContrib">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="NonContr_1">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="AreaSqKm">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="AreaAcres">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="GNIS_ID">
+      <editWidget type="Range">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="States">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="HUC12">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="HUType">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="HUMod">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ToHUC">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Shape_Leng">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Shape_Area">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="NHDPlusID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="VPUID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="TNMID" name="" index="0"/>
+    <alias field="MetaSource" name="" index="1"/>
+    <alias field="SourceData" name="" index="2"/>
+    <alias field="SourceOrig" name="" index="3"/>
+    <alias field="SourceFeat" name="" index="4"/>
+    <alias field="LoadDate" name="" index="5"/>
+    <alias field="NonContrib" name="" index="6"/>
+    <alias field="NonContr_1" name="" index="7"/>
+    <alias field="AreaSqKm" name="" index="8"/>
+    <alias field="AreaAcres" name="" index="9"/>
+    <alias field="GNIS_ID" name="" index="10"/>
+    <alias field="Name" name="" index="11"/>
+    <alias field="States" name="" index="12"/>
+    <alias field="HUC12" name="" index="13"/>
+    <alias field="HUType" name="" index="14"/>
+    <alias field="HUMod" name="" index="15"/>
+    <alias field="ToHUC" name="" index="16"/>
+    <alias field="Shape_Leng" name="" index="17"/>
+    <alias field="Shape_Area" name="" index="18"/>
+    <alias field="NHDPlusID" name="" index="19"/>
+    <alias field="VPUID" name="" index="20"/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default field="TNMID" expression="" applyOnUpdate="0"/>
+    <default field="MetaSource" expression="" applyOnUpdate="0"/>
+    <default field="SourceData" expression="" applyOnUpdate="0"/>
+    <default field="SourceOrig" expression="" applyOnUpdate="0"/>
+    <default field="SourceFeat" expression="" applyOnUpdate="0"/>
+    <default field="LoadDate" expression="" applyOnUpdate="0"/>
+    <default field="NonContrib" expression="" applyOnUpdate="0"/>
+    <default field="NonContr_1" expression="" applyOnUpdate="0"/>
+    <default field="AreaSqKm" expression="" applyOnUpdate="0"/>
+    <default field="AreaAcres" expression="" applyOnUpdate="0"/>
+    <default field="GNIS_ID" expression="" applyOnUpdate="0"/>
+    <default field="Name" expression="" applyOnUpdate="0"/>
+    <default field="States" expression="" applyOnUpdate="0"/>
+    <default field="HUC12" expression="" applyOnUpdate="0"/>
+    <default field="HUType" expression="" applyOnUpdate="0"/>
+    <default field="HUMod" expression="" applyOnUpdate="0"/>
+    <default field="ToHUC" expression="" applyOnUpdate="0"/>
+    <default field="Shape_Leng" expression="" applyOnUpdate="0"/>
+    <default field="Shape_Area" expression="" applyOnUpdate="0"/>
+    <default field="NHDPlusID" expression="" applyOnUpdate="0"/>
+    <default field="VPUID" expression="" applyOnUpdate="0"/>
+  </defaults>
+  <constraints>
+    <constraint field="TNMID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="MetaSource" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceData" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceOrig" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceFeat" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="LoadDate" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="NonContrib" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="NonContr_1" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="AreaSqKm" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="AreaAcres" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="GNIS_ID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Name" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="States" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="HUC12" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="HUType" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="HUMod" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="ToHUC" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Shape_Leng" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Shape_Area" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="NHDPlusID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="VPUID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint field="TNMID" exp="" desc=""/>
+    <constraint field="MetaSource" exp="" desc=""/>
+    <constraint field="SourceData" exp="" desc=""/>
+    <constraint field="SourceOrig" exp="" desc=""/>
+    <constraint field="SourceFeat" exp="" desc=""/>
+    <constraint field="LoadDate" exp="" desc=""/>
+    <constraint field="NonContrib" exp="" desc=""/>
+    <constraint field="NonContr_1" exp="" desc=""/>
+    <constraint field="AreaSqKm" exp="" desc=""/>
+    <constraint field="AreaAcres" exp="" desc=""/>
+    <constraint field="GNIS_ID" exp="" desc=""/>
+    <constraint field="Name" exp="" desc=""/>
+    <constraint field="States" exp="" desc=""/>
+    <constraint field="HUC12" exp="" desc=""/>
+    <constraint field="HUType" exp="" desc=""/>
+    <constraint field="HUMod" exp="" desc=""/>
+    <constraint field="ToHUC" exp="" desc=""/>
+    <constraint field="Shape_Leng" exp="" desc=""/>
+    <constraint field="Shape_Area" exp="" desc=""/>
+    <constraint field="NHDPlusID" exp="" desc=""/>
+    <constraint field="VPUID" exp="" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+    <columns>
+      <column name="TNMID" type="field" hidden="0" width="-1"/>
+      <column name="MetaSource" type="field" hidden="0" width="-1"/>
+      <column name="SourceData" type="field" hidden="0" width="-1"/>
+      <column name="SourceOrig" type="field" hidden="0" width="-1"/>
+      <column name="SourceFeat" type="field" hidden="0" width="-1"/>
+      <column name="LoadDate" type="field" hidden="0" width="-1"/>
+      <column name="AreaSqKm" type="field" hidden="0" width="-1"/>
+      <column name="AreaAcres" type="field" hidden="0" width="-1"/>
+      <column name="GNIS_ID" type="field" hidden="0" width="-1"/>
+      <column name="Name" type="field" hidden="0" width="-1"/>
+      <column name="States" type="field" hidden="0" width="-1"/>
+      <column name="HUType" type="field" hidden="0" width="-1"/>
+      <column name="HUMod" type="field" hidden="0" width="-1"/>
+      <column name="Shape_Leng" type="field" hidden="0" width="-1"/>
+      <column name="Shape_Area" type="field" hidden="0" width="-1"/>
+      <column type="actions" hidden="1" width="-1"/>
+      <column name="NonContrib" type="field" hidden="0" width="-1"/>
+      <column name="NonContr_1" type="field" hidden="0" width="-1"/>
+      <column name="HUC12" type="field" hidden="0" width="-1"/>
+      <column name="ToHUC" type="field" hidden="0" width="-1"/>
+      <column name="NHDPlusID" type="field" hidden="0" width="-1"/>
+      <column name="VPUID" type="field" hidden="0" width="-1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <storedexpressions/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>generatedlayout</editorlayout>
+  <editable>
+    <field name="AreaAcres" editable="1"/>
+    <field name="AreaSqKm" editable="1"/>
+    <field name="GNIS_ID" editable="1"/>
+    <field name="HUC10" editable="1"/>
+    <field name="HUC12" editable="1"/>
+    <field name="HUMod" editable="1"/>
+    <field name="HUType" editable="1"/>
+    <field name="LoadDate" editable="1"/>
+    <field name="MetaSource" editable="1"/>
+    <field name="NHDPlusID" editable="1"/>
+    <field name="Name" editable="1"/>
+    <field name="NonContr_1" editable="1"/>
+    <field name="NonContrib" editable="1"/>
+    <field name="Shape_Area" editable="1"/>
+    <field name="Shape_Leng" editable="1"/>
+    <field name="SourceData" editable="1"/>
+    <field name="SourceFeat" editable="1"/>
+    <field name="SourceOrig" editable="1"/>
+    <field name="States" editable="1"/>
+    <field name="TNMID" editable="1"/>
+    <field name="ToHUC" editable="1"/>
+    <field name="VPUID" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="AreaAcres" labelOnTop="0"/>
+    <field name="AreaSqKm" labelOnTop="0"/>
+    <field name="GNIS_ID" labelOnTop="0"/>
+    <field name="HUC10" labelOnTop="0"/>
+    <field name="HUC12" labelOnTop="0"/>
+    <field name="HUMod" labelOnTop="0"/>
+    <field name="HUType" labelOnTop="0"/>
+    <field name="LoadDate" labelOnTop="0"/>
+    <field name="MetaSource" labelOnTop="0"/>
+    <field name="NHDPlusID" labelOnTop="0"/>
+    <field name="Name" labelOnTop="0"/>
+    <field name="NonContr_1" labelOnTop="0"/>
+    <field name="NonContrib" labelOnTop="0"/>
+    <field name="Shape_Area" labelOnTop="0"/>
+    <field name="Shape_Leng" labelOnTop="0"/>
+    <field name="SourceData" labelOnTop="0"/>
+    <field name="SourceFeat" labelOnTop="0"/>
+    <field name="SourceOrig" labelOnTop="0"/>
+    <field name="States" labelOnTop="0"/>
+    <field name="TNMID" labelOnTop="0"/>
+    <field name="ToHUC" labelOnTop="0"/>
+    <field name="VPUID" labelOnTop="0"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>Name</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/Symbology/qgis/RSContext/wbdhu2.qml
+++ b/Symbology/qgis/RSContext/wbdhu2.qml
@@ -1,0 +1,441 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis simplifyDrawingHints="1" version="3.12.1-București" labelsEnabled="1" simplifyMaxScale="1" simplifyLocal="1" readOnly="0" maxScale="0" simplifyAlgorithm="0" simplifyDrawingTol="1" styleCategories="AllStyleCategories" minScale="100000000" hasScaleBasedVisibilityFlag="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+    <symbols>
+      <symbol name="0" type="fill" clip_to_extent="1" force_rhr="0" alpha="1">
+        <layer enabled="1" locked="0" class="SimpleFill" pass="0">
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="190,207,80,0" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="227,26,28,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="1.75" k="outline_width"/>
+          <prop v="Pixel" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style fontItalic="0" fontWordSpacing="0" namedStyle="Regular" fontCapitals="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" multilineHeight="1" fontSize="10" isExpression="1" fontKerning="1" fieldName=" &quot;Name&quot;   +  '\n'  +   &quot;HUC2&quot; " textOrientation="horizontal" fontUnderline="0" fontStrikeout="0" useSubstitutions="0" fontSizeUnit="Point" fontFamily="MS Shell Dlg 2" textOpacity="1" textColor="255,255,255,255" fontWeight="50" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0">
+        <text-buffer bufferColor="255,255,255,255" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="128" bufferOpacity="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferSizeUnits="MM"/>
+        <text-mask maskEnabled="1" maskType="0" maskJoinStyle="128" maskSize="1.5" maskSizeUnits="MM" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1"/>
+        <background shapeBorderColor="128,128,128,255" shapeBlendMode="0" shapeOffsetUnit="MM" shapeBorderWidthUnit="MM" shapeType="0" shapeDraw="0" shapeSVGFile="" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeSizeUnit="MM" shapeRotation="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeJoinStyle="64" shapeOpacity="1" shapeRotationType="0" shapeRadiiUnit="MM" shapeOffsetY="0" shapeOffsetX="0" shapeFillColor="255,255,255,255" shapeSizeX="0" shapeSizeType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0">
+          <symbol name="markerSymbol" type="marker" clip_to_extent="1" force_rhr="0" alpha="1">
+            <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
+              <prop v="0" k="angle"/>
+              <prop v="255,158,23,255" k="color"/>
+              <prop v="1" k="horizontal_anchor_point"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="circle" k="name"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="35,35,35,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0" k="outline_width"/>
+              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="diameter" k="scale_method"/>
+              <prop v="2" k="size"/>
+              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+              <prop v="MM" k="size_unit"/>
+              <prop v="1" k="vertical_anchor_point"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowOpacity="0.7" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowOffsetAngle="135" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetDist="1" shadowUnder="0" shadowRadiusUnit="MM" shadowOffsetUnit="MM" shadowOffsetGlobal="1" shadowBlendMode="6" shadowDraw="1"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </dd_properties>
+        <substitutions/>
+      </text-style>
+      <text-format autoWrapLength="0" addDirectionSymbol="0" decimals="3" useMaxLineLengthForAutoWrap="1" multilineAlign="1" formatNumbers="0" wrapChar="" rightDirectionSymbol=">" placeDirectionSymbol="0" leftDirectionSymbol="&lt;" reverseDirectionSymbol="0" plussign="0"/>
+      <placement xOffset="0" overrunDistance="0" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" priority="5" geometryGenerator="" repeatDistanceUnits="MM" geometryGeneratorEnabled="0" distUnits="MM" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" fitInPolygonOnly="0" placementFlags="10" preserveRotation="1" centroidInside="0" overrunDistanceUnit="MM" layerType="PolygonGeometry" dist="0" placement="0" maxCurvedCharAngleOut="-25" offsetUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" rotationAngle="0" quadOffset="4" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" centroidWhole="0"/>
+      <rendering obstacleFactor="1" obstacle="1" minFeatureSize="0" labelPerPart="0" drawLabels="1" zIndex="0" displayAll="0" scaleMin="0" fontMaxPixelSize="10000" obstacleType="1" maxNumLabels="2000" limitNumLabels="0" mergeLines="0" scaleVisibility="0" upsidedownLabels="0" scaleMax="0" fontLimitPixelSize="0" fontMinPixelSize="3"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option name="name" value="" type="QString"/>
+          <Option name="properties"/>
+          <Option name="type" value="collection" type="QString"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+          <Option name="ddProperties" type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+          <Option name="drawToAllParts" value="false" type="bool"/>
+          <Option name="enabled" value="1" type="QString"/>
+          <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot; alpha=&quot;1&quot;>&lt;layer enabled=&quot;1&quot; locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+          <Option name="minLength" value="0" type="double"/>
+          <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="minLengthUnit" value="MM" type="QString"/>
+          <Option name="offsetFromAnchor" value="0" type="double"/>
+          <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+          <Option name="offsetFromLabel" value="0" type="double"/>
+          <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
+  <customproperties>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+    <DiagramCategory sizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" diagramOrientation="Up" showAxis="1" direction="0" labelPlacementMethod="XHeight" minimumSize="0" height="15" maxScaleDenominator="1e+08" width="15" spacingUnitScale="3x:0,0,0,0,0,0" scaleDependency="Area" lineSizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" penAlpha="255" spacingUnit="MM" backgroundAlpha="255" barWidth="5" backgroundColor="#ffffff" penWidth="0" rotationOffset="270" enabled="0" spacing="5" opacity="1" scaleBasedVisibility="0" sizeType="MM" penColor="#000000">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute field="" label="" color="#000000"/>
+      <axisSymbol>
+        <symbol name="" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
+          <layer enabled="1" locked="0" class="SimpleLine" pass="0">
+            <prop v="square" k="capstyle"/>
+            <prop v="5;2" k="customdash"/>
+            <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+            <prop v="MM" k="customdash_unit"/>
+            <prop v="0" k="draw_inside_polygon"/>
+            <prop v="bevel" k="joinstyle"/>
+            <prop v="35,35,35,255" k="line_color"/>
+            <prop v="solid" k="line_style"/>
+            <prop v="0.26" k="line_width"/>
+            <prop v="MM" k="line_width_unit"/>
+            <prop v="0" k="offset"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="0" k="ring_filter"/>
+            <prop v="0" k="use_custom_dash"/>
+            <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </axisSymbol>
+    </DiagramCategory>
+  </SingleCategoryDiagramRenderer>
+  <DiagramLayerSettings obstacle="0" placement="1" zIndex="0" linePlacementFlags="18" dist="0" showAll="1" priority="0">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration type="Map">
+      <Option name="QgsGeometryGapCheck" type="Map">
+        <Option name="allowedGapsBuffer" value="0" type="double"/>
+        <Option name="allowedGapsEnabled" value="false" type="bool"/>
+        <Option name="allowedGapsLayer" value="" type="QString"/>
+      </Option>
+    </checkConfiguration>
+  </geometryOptions>
+  <referencedLayers/>
+  <referencingLayers/>
+  <fieldConfiguration>
+    <field name="TNMID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="MetaSource">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceData">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceOrig">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceFeat">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="LoadDate">
+      <editWidget type="DateTime">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="AreaSqKm">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="AreaAcres">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="GNIS_ID">
+      <editWidget type="Range">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="States">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="HUC2">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Shape_Leng">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Shape_Area">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="TNMID" name="" index="0"/>
+    <alias field="MetaSource" name="" index="1"/>
+    <alias field="SourceData" name="" index="2"/>
+    <alias field="SourceOrig" name="" index="3"/>
+    <alias field="SourceFeat" name="" index="4"/>
+    <alias field="LoadDate" name="" index="5"/>
+    <alias field="AreaSqKm" name="" index="6"/>
+    <alias field="AreaAcres" name="" index="7"/>
+    <alias field="GNIS_ID" name="" index="8"/>
+    <alias field="Name" name="" index="9"/>
+    <alias field="States" name="" index="10"/>
+    <alias field="HUC2" name="" index="11"/>
+    <alias field="Shape_Leng" name="" index="12"/>
+    <alias field="Shape_Area" name="" index="13"/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default field="TNMID" expression="" applyOnUpdate="0"/>
+    <default field="MetaSource" expression="" applyOnUpdate="0"/>
+    <default field="SourceData" expression="" applyOnUpdate="0"/>
+    <default field="SourceOrig" expression="" applyOnUpdate="0"/>
+    <default field="SourceFeat" expression="" applyOnUpdate="0"/>
+    <default field="LoadDate" expression="" applyOnUpdate="0"/>
+    <default field="AreaSqKm" expression="" applyOnUpdate="0"/>
+    <default field="AreaAcres" expression="" applyOnUpdate="0"/>
+    <default field="GNIS_ID" expression="" applyOnUpdate="0"/>
+    <default field="Name" expression="" applyOnUpdate="0"/>
+    <default field="States" expression="" applyOnUpdate="0"/>
+    <default field="HUC2" expression="" applyOnUpdate="0"/>
+    <default field="Shape_Leng" expression="" applyOnUpdate="0"/>
+    <default field="Shape_Area" expression="" applyOnUpdate="0"/>
+  </defaults>
+  <constraints>
+    <constraint field="TNMID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="MetaSource" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceData" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceOrig" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceFeat" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="LoadDate" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="AreaSqKm" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="AreaAcres" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="GNIS_ID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Name" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="States" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="HUC2" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Shape_Leng" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Shape_Area" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint field="TNMID" exp="" desc=""/>
+    <constraint field="MetaSource" exp="" desc=""/>
+    <constraint field="SourceData" exp="" desc=""/>
+    <constraint field="SourceOrig" exp="" desc=""/>
+    <constraint field="SourceFeat" exp="" desc=""/>
+    <constraint field="LoadDate" exp="" desc=""/>
+    <constraint field="AreaSqKm" exp="" desc=""/>
+    <constraint field="AreaAcres" exp="" desc=""/>
+    <constraint field="GNIS_ID" exp="" desc=""/>
+    <constraint field="Name" exp="" desc=""/>
+    <constraint field="States" exp="" desc=""/>
+    <constraint field="HUC2" exp="" desc=""/>
+    <constraint field="Shape_Leng" exp="" desc=""/>
+    <constraint field="Shape_Area" exp="" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+    <columns>
+      <column name="TNMID" type="field" hidden="0" width="-1"/>
+      <column name="MetaSource" type="field" hidden="0" width="-1"/>
+      <column name="SourceData" type="field" hidden="0" width="-1"/>
+      <column name="SourceOrig" type="field" hidden="0" width="-1"/>
+      <column name="SourceFeat" type="field" hidden="0" width="-1"/>
+      <column name="LoadDate" type="field" hidden="0" width="-1"/>
+      <column name="AreaSqKm" type="field" hidden="0" width="-1"/>
+      <column name="AreaAcres" type="field" hidden="0" width="-1"/>
+      <column name="GNIS_ID" type="field" hidden="0" width="-1"/>
+      <column name="Name" type="field" hidden="0" width="-1"/>
+      <column name="States" type="field" hidden="0" width="-1"/>
+      <column name="Shape_Leng" type="field" hidden="0" width="-1"/>
+      <column name="Shape_Area" type="field" hidden="0" width="-1"/>
+      <column type="actions" hidden="1" width="-1"/>
+      <column name="HUC2" type="field" hidden="0" width="-1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <storedexpressions/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>generatedlayout</editorlayout>
+  <editable>
+    <field name="AreaAcres" editable="1"/>
+    <field name="AreaSqKm" editable="1"/>
+    <field name="GNIS_ID" editable="1"/>
+    <field name="HUC10" editable="1"/>
+    <field name="HUC2" editable="1"/>
+    <field name="HUC8" editable="1"/>
+    <field name="HUMod" editable="1"/>
+    <field name="HUType" editable="1"/>
+    <field name="LoadDate" editable="1"/>
+    <field name="MetaSource" editable="1"/>
+    <field name="Name" editable="1"/>
+    <field name="Shape_Area" editable="1"/>
+    <field name="Shape_Leng" editable="1"/>
+    <field name="SourceData" editable="1"/>
+    <field name="SourceFeat" editable="1"/>
+    <field name="SourceOrig" editable="1"/>
+    <field name="States" editable="1"/>
+    <field name="TNMID" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="AreaAcres" labelOnTop="0"/>
+    <field name="AreaSqKm" labelOnTop="0"/>
+    <field name="GNIS_ID" labelOnTop="0"/>
+    <field name="HUC10" labelOnTop="0"/>
+    <field name="HUC2" labelOnTop="0"/>
+    <field name="HUC8" labelOnTop="0"/>
+    <field name="HUMod" labelOnTop="0"/>
+    <field name="HUType" labelOnTop="0"/>
+    <field name="LoadDate" labelOnTop="0"/>
+    <field name="MetaSource" labelOnTop="0"/>
+    <field name="Name" labelOnTop="0"/>
+    <field name="Shape_Area" labelOnTop="0"/>
+    <field name="Shape_Leng" labelOnTop="0"/>
+    <field name="SourceData" labelOnTop="0"/>
+    <field name="SourceFeat" labelOnTop="0"/>
+    <field name="SourceOrig" labelOnTop="0"/>
+    <field name="States" labelOnTop="0"/>
+    <field name="TNMID" labelOnTop="0"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>Name</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/Symbology/qgis/RSContext/wbdhu4.qml
+++ b/Symbology/qgis/RSContext/wbdhu4.qml
@@ -1,0 +1,441 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis simplifyDrawingHints="1" version="3.12.1-București" labelsEnabled="1" simplifyMaxScale="1" simplifyLocal="1" readOnly="0" maxScale="0" simplifyAlgorithm="0" simplifyDrawingTol="1" styleCategories="AllStyleCategories" minScale="100000000" hasScaleBasedVisibilityFlag="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+    <symbols>
+      <symbol name="0" type="fill" clip_to_extent="1" force_rhr="0" alpha="1">
+        <layer enabled="1" locked="0" class="SimpleFill" pass="0">
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="190,207,80,0" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="227,26,28,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="1.75" k="outline_width"/>
+          <prop v="Pixel" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style fontItalic="0" fontWordSpacing="0" namedStyle="Regular" fontCapitals="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" multilineHeight="1" fontSize="10" isExpression="1" fontKerning="1" fieldName=" &quot;Name&quot;  +  '\n'  +   &quot;HUC4&quot; " textOrientation="horizontal" fontUnderline="0" fontStrikeout="0" useSubstitutions="0" fontSizeUnit="Point" fontFamily="MS Shell Dlg 2" textOpacity="1" textColor="255,255,255,255" fontWeight="50" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0">
+        <text-buffer bufferColor="255,255,255,255" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="128" bufferOpacity="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferSizeUnits="MM"/>
+        <text-mask maskEnabled="1" maskType="0" maskJoinStyle="128" maskSize="1.5" maskSizeUnits="MM" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1"/>
+        <background shapeBorderColor="128,128,128,255" shapeBlendMode="0" shapeOffsetUnit="MM" shapeBorderWidthUnit="MM" shapeType="0" shapeDraw="0" shapeSVGFile="" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeSizeUnit="MM" shapeRotation="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeJoinStyle="64" shapeOpacity="1" shapeRotationType="0" shapeRadiiUnit="MM" shapeOffsetY="0" shapeOffsetX="0" shapeFillColor="255,255,255,255" shapeSizeX="0" shapeSizeType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0">
+          <symbol name="markerSymbol" type="marker" clip_to_extent="1" force_rhr="0" alpha="1">
+            <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
+              <prop v="0" k="angle"/>
+              <prop v="255,158,23,255" k="color"/>
+              <prop v="1" k="horizontal_anchor_point"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="circle" k="name"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="35,35,35,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0" k="outline_width"/>
+              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="diameter" k="scale_method"/>
+              <prop v="2" k="size"/>
+              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+              <prop v="MM" k="size_unit"/>
+              <prop v="1" k="vertical_anchor_point"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowOpacity="0.7" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowOffsetAngle="135" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetDist="1" shadowUnder="0" shadowRadiusUnit="MM" shadowOffsetUnit="MM" shadowOffsetGlobal="1" shadowBlendMode="6" shadowDraw="1"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </dd_properties>
+        <substitutions/>
+      </text-style>
+      <text-format autoWrapLength="0" addDirectionSymbol="0" decimals="3" useMaxLineLengthForAutoWrap="1" multilineAlign="1" formatNumbers="0" wrapChar="" rightDirectionSymbol=">" placeDirectionSymbol="0" leftDirectionSymbol="&lt;" reverseDirectionSymbol="0" plussign="0"/>
+      <placement xOffset="0" overrunDistance="0" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" priority="5" geometryGenerator="" repeatDistanceUnits="MM" geometryGeneratorEnabled="0" distUnits="MM" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" fitInPolygonOnly="0" placementFlags="10" preserveRotation="1" centroidInside="0" overrunDistanceUnit="MM" layerType="PolygonGeometry" dist="0" placement="0" maxCurvedCharAngleOut="-25" offsetUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" rotationAngle="0" quadOffset="4" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" centroidWhole="0"/>
+      <rendering obstacleFactor="1" obstacle="1" minFeatureSize="0" labelPerPart="0" drawLabels="1" zIndex="0" displayAll="0" scaleMin="0" fontMaxPixelSize="10000" obstacleType="1" maxNumLabels="2000" limitNumLabels="0" mergeLines="0" scaleVisibility="0" upsidedownLabels="0" scaleMax="0" fontLimitPixelSize="0" fontMinPixelSize="3"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option name="name" value="" type="QString"/>
+          <Option name="properties"/>
+          <Option name="type" value="collection" type="QString"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+          <Option name="ddProperties" type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+          <Option name="drawToAllParts" value="false" type="bool"/>
+          <Option name="enabled" value="1" type="QString"/>
+          <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot; alpha=&quot;1&quot;>&lt;layer enabled=&quot;1&quot; locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+          <Option name="minLength" value="0" type="double"/>
+          <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="minLengthUnit" value="MM" type="QString"/>
+          <Option name="offsetFromAnchor" value="0" type="double"/>
+          <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+          <Option name="offsetFromLabel" value="0" type="double"/>
+          <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
+  <customproperties>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+    <DiagramCategory sizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" diagramOrientation="Up" showAxis="1" direction="0" labelPlacementMethod="XHeight" minimumSize="0" height="15" maxScaleDenominator="1e+08" width="15" spacingUnitScale="3x:0,0,0,0,0,0" scaleDependency="Area" lineSizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" penAlpha="255" spacingUnit="MM" backgroundAlpha="255" barWidth="5" backgroundColor="#ffffff" penWidth="0" rotationOffset="270" enabled="0" spacing="5" opacity="1" scaleBasedVisibility="0" sizeType="MM" penColor="#000000">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute field="" label="" color="#000000"/>
+      <axisSymbol>
+        <symbol name="" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
+          <layer enabled="1" locked="0" class="SimpleLine" pass="0">
+            <prop v="square" k="capstyle"/>
+            <prop v="5;2" k="customdash"/>
+            <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+            <prop v="MM" k="customdash_unit"/>
+            <prop v="0" k="draw_inside_polygon"/>
+            <prop v="bevel" k="joinstyle"/>
+            <prop v="35,35,35,255" k="line_color"/>
+            <prop v="solid" k="line_style"/>
+            <prop v="0.26" k="line_width"/>
+            <prop v="MM" k="line_width_unit"/>
+            <prop v="0" k="offset"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="0" k="ring_filter"/>
+            <prop v="0" k="use_custom_dash"/>
+            <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </axisSymbol>
+    </DiagramCategory>
+  </SingleCategoryDiagramRenderer>
+  <DiagramLayerSettings obstacle="0" placement="1" zIndex="0" linePlacementFlags="18" dist="0" showAll="1" priority="0">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration type="Map">
+      <Option name="QgsGeometryGapCheck" type="Map">
+        <Option name="allowedGapsBuffer" value="0" type="double"/>
+        <Option name="allowedGapsEnabled" value="false" type="bool"/>
+        <Option name="allowedGapsLayer" value="" type="QString"/>
+      </Option>
+    </checkConfiguration>
+  </geometryOptions>
+  <referencedLayers/>
+  <referencingLayers/>
+  <fieldConfiguration>
+    <field name="TNMID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="MetaSource">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceData">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceOrig">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceFeat">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="LoadDate">
+      <editWidget type="DateTime">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="AreaSqKm">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="AreaAcres">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="GNIS_ID">
+      <editWidget type="Range">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="States">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="HUC4">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Shape_Leng">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Shape_Area">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="TNMID" name="" index="0"/>
+    <alias field="MetaSource" name="" index="1"/>
+    <alias field="SourceData" name="" index="2"/>
+    <alias field="SourceOrig" name="" index="3"/>
+    <alias field="SourceFeat" name="" index="4"/>
+    <alias field="LoadDate" name="" index="5"/>
+    <alias field="AreaSqKm" name="" index="6"/>
+    <alias field="AreaAcres" name="" index="7"/>
+    <alias field="GNIS_ID" name="" index="8"/>
+    <alias field="Name" name="" index="9"/>
+    <alias field="States" name="" index="10"/>
+    <alias field="HUC4" name="" index="11"/>
+    <alias field="Shape_Leng" name="" index="12"/>
+    <alias field="Shape_Area" name="" index="13"/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default field="TNMID" expression="" applyOnUpdate="0"/>
+    <default field="MetaSource" expression="" applyOnUpdate="0"/>
+    <default field="SourceData" expression="" applyOnUpdate="0"/>
+    <default field="SourceOrig" expression="" applyOnUpdate="0"/>
+    <default field="SourceFeat" expression="" applyOnUpdate="0"/>
+    <default field="LoadDate" expression="" applyOnUpdate="0"/>
+    <default field="AreaSqKm" expression="" applyOnUpdate="0"/>
+    <default field="AreaAcres" expression="" applyOnUpdate="0"/>
+    <default field="GNIS_ID" expression="" applyOnUpdate="0"/>
+    <default field="Name" expression="" applyOnUpdate="0"/>
+    <default field="States" expression="" applyOnUpdate="0"/>
+    <default field="HUC4" expression="" applyOnUpdate="0"/>
+    <default field="Shape_Leng" expression="" applyOnUpdate="0"/>
+    <default field="Shape_Area" expression="" applyOnUpdate="0"/>
+  </defaults>
+  <constraints>
+    <constraint field="TNMID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="MetaSource" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceData" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceOrig" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceFeat" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="LoadDate" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="AreaSqKm" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="AreaAcres" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="GNIS_ID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Name" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="States" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="HUC4" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Shape_Leng" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Shape_Area" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint field="TNMID" exp="" desc=""/>
+    <constraint field="MetaSource" exp="" desc=""/>
+    <constraint field="SourceData" exp="" desc=""/>
+    <constraint field="SourceOrig" exp="" desc=""/>
+    <constraint field="SourceFeat" exp="" desc=""/>
+    <constraint field="LoadDate" exp="" desc=""/>
+    <constraint field="AreaSqKm" exp="" desc=""/>
+    <constraint field="AreaAcres" exp="" desc=""/>
+    <constraint field="GNIS_ID" exp="" desc=""/>
+    <constraint field="Name" exp="" desc=""/>
+    <constraint field="States" exp="" desc=""/>
+    <constraint field="HUC4" exp="" desc=""/>
+    <constraint field="Shape_Leng" exp="" desc=""/>
+    <constraint field="Shape_Area" exp="" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+    <columns>
+      <column name="TNMID" type="field" hidden="0" width="-1"/>
+      <column name="MetaSource" type="field" hidden="0" width="-1"/>
+      <column name="SourceData" type="field" hidden="0" width="-1"/>
+      <column name="SourceOrig" type="field" hidden="0" width="-1"/>
+      <column name="SourceFeat" type="field" hidden="0" width="-1"/>
+      <column name="LoadDate" type="field" hidden="0" width="-1"/>
+      <column name="AreaSqKm" type="field" hidden="0" width="-1"/>
+      <column name="AreaAcres" type="field" hidden="0" width="-1"/>
+      <column name="GNIS_ID" type="field" hidden="0" width="-1"/>
+      <column name="Name" type="field" hidden="0" width="-1"/>
+      <column name="States" type="field" hidden="0" width="-1"/>
+      <column name="Shape_Leng" type="field" hidden="0" width="-1"/>
+      <column name="Shape_Area" type="field" hidden="0" width="-1"/>
+      <column type="actions" hidden="1" width="-1"/>
+      <column name="HUC4" type="field" hidden="0" width="-1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <storedexpressions/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>generatedlayout</editorlayout>
+  <editable>
+    <field name="AreaAcres" editable="1"/>
+    <field name="AreaSqKm" editable="1"/>
+    <field name="GNIS_ID" editable="1"/>
+    <field name="HUC10" editable="1"/>
+    <field name="HUC4" editable="1"/>
+    <field name="HUC8" editable="1"/>
+    <field name="HUMod" editable="1"/>
+    <field name="HUType" editable="1"/>
+    <field name="LoadDate" editable="1"/>
+    <field name="MetaSource" editable="1"/>
+    <field name="Name" editable="1"/>
+    <field name="Shape_Area" editable="1"/>
+    <field name="Shape_Leng" editable="1"/>
+    <field name="SourceData" editable="1"/>
+    <field name="SourceFeat" editable="1"/>
+    <field name="SourceOrig" editable="1"/>
+    <field name="States" editable="1"/>
+    <field name="TNMID" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="AreaAcres" labelOnTop="0"/>
+    <field name="AreaSqKm" labelOnTop="0"/>
+    <field name="GNIS_ID" labelOnTop="0"/>
+    <field name="HUC10" labelOnTop="0"/>
+    <field name="HUC4" labelOnTop="0"/>
+    <field name="HUC8" labelOnTop="0"/>
+    <field name="HUMod" labelOnTop="0"/>
+    <field name="HUType" labelOnTop="0"/>
+    <field name="LoadDate" labelOnTop="0"/>
+    <field name="MetaSource" labelOnTop="0"/>
+    <field name="Name" labelOnTop="0"/>
+    <field name="Shape_Area" labelOnTop="0"/>
+    <field name="Shape_Leng" labelOnTop="0"/>
+    <field name="SourceData" labelOnTop="0"/>
+    <field name="SourceFeat" labelOnTop="0"/>
+    <field name="SourceOrig" labelOnTop="0"/>
+    <field name="States" labelOnTop="0"/>
+    <field name="TNMID" labelOnTop="0"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>Name</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/Symbology/qgis/RSContext/wbdhu6.qml
+++ b/Symbology/qgis/RSContext/wbdhu6.qml
@@ -1,0 +1,441 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis simplifyDrawingHints="1" version="3.12.1-București" labelsEnabled="1" simplifyMaxScale="1" simplifyLocal="1" readOnly="0" maxScale="0" simplifyAlgorithm="0" simplifyDrawingTol="1" styleCategories="AllStyleCategories" minScale="100000000" hasScaleBasedVisibilityFlag="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+    <symbols>
+      <symbol name="0" type="fill" clip_to_extent="1" force_rhr="0" alpha="1">
+        <layer enabled="1" locked="0" class="SimpleFill" pass="0">
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="190,207,80,0" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="227,26,28,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="1.75" k="outline_width"/>
+          <prop v="Pixel" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style fontItalic="0" fontWordSpacing="0" namedStyle="Regular" fontCapitals="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" multilineHeight="1" fontSize="10" isExpression="1" fontKerning="1" fieldName=" &quot;Name&quot;  +  '\n'  +   &quot;HUC6&quot; " textOrientation="horizontal" fontUnderline="0" fontStrikeout="0" useSubstitutions="0" fontSizeUnit="Point" fontFamily="MS Shell Dlg 2" textOpacity="1" textColor="255,255,255,255" fontWeight="50" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0">
+        <text-buffer bufferColor="255,255,255,255" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="128" bufferOpacity="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferSizeUnits="MM"/>
+        <text-mask maskEnabled="1" maskType="0" maskJoinStyle="128" maskSize="1.5" maskSizeUnits="MM" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1"/>
+        <background shapeBorderColor="128,128,128,255" shapeBlendMode="0" shapeOffsetUnit="MM" shapeBorderWidthUnit="MM" shapeType="0" shapeDraw="0" shapeSVGFile="" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeSizeUnit="MM" shapeRotation="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeJoinStyle="64" shapeOpacity="1" shapeRotationType="0" shapeRadiiUnit="MM" shapeOffsetY="0" shapeOffsetX="0" shapeFillColor="255,255,255,255" shapeSizeX="0" shapeSizeType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0">
+          <symbol name="markerSymbol" type="marker" clip_to_extent="1" force_rhr="0" alpha="1">
+            <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
+              <prop v="0" k="angle"/>
+              <prop v="255,158,23,255" k="color"/>
+              <prop v="1" k="horizontal_anchor_point"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="circle" k="name"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="35,35,35,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0" k="outline_width"/>
+              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="diameter" k="scale_method"/>
+              <prop v="2" k="size"/>
+              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+              <prop v="MM" k="size_unit"/>
+              <prop v="1" k="vertical_anchor_point"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowOpacity="0.7" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowOffsetAngle="135" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetDist="1" shadowUnder="0" shadowRadiusUnit="MM" shadowOffsetUnit="MM" shadowOffsetGlobal="1" shadowBlendMode="6" shadowDraw="1"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </dd_properties>
+        <substitutions/>
+      </text-style>
+      <text-format autoWrapLength="0" addDirectionSymbol="0" decimals="3" useMaxLineLengthForAutoWrap="1" multilineAlign="1" formatNumbers="0" wrapChar="" rightDirectionSymbol=">" placeDirectionSymbol="0" leftDirectionSymbol="&lt;" reverseDirectionSymbol="0" plussign="0"/>
+      <placement xOffset="0" overrunDistance="0" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" priority="5" geometryGenerator="" repeatDistanceUnits="MM" geometryGeneratorEnabled="0" distUnits="MM" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" fitInPolygonOnly="0" placementFlags="10" preserveRotation="1" centroidInside="0" overrunDistanceUnit="MM" layerType="PolygonGeometry" dist="0" placement="0" maxCurvedCharAngleOut="-25" offsetUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" rotationAngle="0" quadOffset="4" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" centroidWhole="0"/>
+      <rendering obstacleFactor="1" obstacle="1" minFeatureSize="0" labelPerPart="0" drawLabels="1" zIndex="0" displayAll="0" scaleMin="0" fontMaxPixelSize="10000" obstacleType="1" maxNumLabels="2000" limitNumLabels="0" mergeLines="0" scaleVisibility="0" upsidedownLabels="0" scaleMax="0" fontLimitPixelSize="0" fontMinPixelSize="3"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option name="name" value="" type="QString"/>
+          <Option name="properties"/>
+          <Option name="type" value="collection" type="QString"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+          <Option name="ddProperties" type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+          <Option name="drawToAllParts" value="false" type="bool"/>
+          <Option name="enabled" value="1" type="QString"/>
+          <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot; alpha=&quot;1&quot;>&lt;layer enabled=&quot;1&quot; locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+          <Option name="minLength" value="0" type="double"/>
+          <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="minLengthUnit" value="MM" type="QString"/>
+          <Option name="offsetFromAnchor" value="0" type="double"/>
+          <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+          <Option name="offsetFromLabel" value="0" type="double"/>
+          <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
+  <customproperties>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+    <DiagramCategory sizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" diagramOrientation="Up" showAxis="1" direction="0" labelPlacementMethod="XHeight" minimumSize="0" height="15" maxScaleDenominator="1e+08" width="15" spacingUnitScale="3x:0,0,0,0,0,0" scaleDependency="Area" lineSizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" penAlpha="255" spacingUnit="MM" backgroundAlpha="255" barWidth="5" backgroundColor="#ffffff" penWidth="0" rotationOffset="270" enabled="0" spacing="5" opacity="1" scaleBasedVisibility="0" sizeType="MM" penColor="#000000">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <attribute field="" label="" color="#000000"/>
+      <axisSymbol>
+        <symbol name="" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
+          <layer enabled="1" locked="0" class="SimpleLine" pass="0">
+            <prop v="square" k="capstyle"/>
+            <prop v="5;2" k="customdash"/>
+            <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+            <prop v="MM" k="customdash_unit"/>
+            <prop v="0" k="draw_inside_polygon"/>
+            <prop v="bevel" k="joinstyle"/>
+            <prop v="35,35,35,255" k="line_color"/>
+            <prop v="solid" k="line_style"/>
+            <prop v="0.26" k="line_width"/>
+            <prop v="MM" k="line_width_unit"/>
+            <prop v="0" k="offset"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="0" k="ring_filter"/>
+            <prop v="0" k="use_custom_dash"/>
+            <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </axisSymbol>
+    </DiagramCategory>
+  </SingleCategoryDiagramRenderer>
+  <DiagramLayerSettings obstacle="0" placement="1" zIndex="0" linePlacementFlags="18" dist="0" showAll="1" priority="0">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration type="Map">
+      <Option name="QgsGeometryGapCheck" type="Map">
+        <Option name="allowedGapsBuffer" value="0" type="double"/>
+        <Option name="allowedGapsEnabled" value="false" type="bool"/>
+        <Option name="allowedGapsLayer" value="" type="QString"/>
+      </Option>
+    </checkConfiguration>
+  </geometryOptions>
+  <referencedLayers/>
+  <referencingLayers/>
+  <fieldConfiguration>
+    <field name="TNMID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="MetaSource">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceData">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceOrig">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceFeat">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="LoadDate">
+      <editWidget type="DateTime">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="AreaSqKm">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="AreaAcres">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="GNIS_ID">
+      <editWidget type="Range">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="States">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="HUC6">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Shape_Leng">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Shape_Area">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="TNMID" name="" index="0"/>
+    <alias field="MetaSource" name="" index="1"/>
+    <alias field="SourceData" name="" index="2"/>
+    <alias field="SourceOrig" name="" index="3"/>
+    <alias field="SourceFeat" name="" index="4"/>
+    <alias field="LoadDate" name="" index="5"/>
+    <alias field="AreaSqKm" name="" index="6"/>
+    <alias field="AreaAcres" name="" index="7"/>
+    <alias field="GNIS_ID" name="" index="8"/>
+    <alias field="Name" name="" index="9"/>
+    <alias field="States" name="" index="10"/>
+    <alias field="HUC6" name="" index="11"/>
+    <alias field="Shape_Leng" name="" index="12"/>
+    <alias field="Shape_Area" name="" index="13"/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default field="TNMID" expression="" applyOnUpdate="0"/>
+    <default field="MetaSource" expression="" applyOnUpdate="0"/>
+    <default field="SourceData" expression="" applyOnUpdate="0"/>
+    <default field="SourceOrig" expression="" applyOnUpdate="0"/>
+    <default field="SourceFeat" expression="" applyOnUpdate="0"/>
+    <default field="LoadDate" expression="" applyOnUpdate="0"/>
+    <default field="AreaSqKm" expression="" applyOnUpdate="0"/>
+    <default field="AreaAcres" expression="" applyOnUpdate="0"/>
+    <default field="GNIS_ID" expression="" applyOnUpdate="0"/>
+    <default field="Name" expression="" applyOnUpdate="0"/>
+    <default field="States" expression="" applyOnUpdate="0"/>
+    <default field="HUC6" expression="" applyOnUpdate="0"/>
+    <default field="Shape_Leng" expression="" applyOnUpdate="0"/>
+    <default field="Shape_Area" expression="" applyOnUpdate="0"/>
+  </defaults>
+  <constraints>
+    <constraint field="TNMID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="MetaSource" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceData" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceOrig" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceFeat" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="LoadDate" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="AreaSqKm" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="AreaAcres" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="GNIS_ID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Name" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="States" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="HUC6" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Shape_Leng" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Shape_Area" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint field="TNMID" exp="" desc=""/>
+    <constraint field="MetaSource" exp="" desc=""/>
+    <constraint field="SourceData" exp="" desc=""/>
+    <constraint field="SourceOrig" exp="" desc=""/>
+    <constraint field="SourceFeat" exp="" desc=""/>
+    <constraint field="LoadDate" exp="" desc=""/>
+    <constraint field="AreaSqKm" exp="" desc=""/>
+    <constraint field="AreaAcres" exp="" desc=""/>
+    <constraint field="GNIS_ID" exp="" desc=""/>
+    <constraint field="Name" exp="" desc=""/>
+    <constraint field="States" exp="" desc=""/>
+    <constraint field="HUC6" exp="" desc=""/>
+    <constraint field="Shape_Leng" exp="" desc=""/>
+    <constraint field="Shape_Area" exp="" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+    <columns>
+      <column name="TNMID" type="field" hidden="0" width="-1"/>
+      <column name="MetaSource" type="field" hidden="0" width="-1"/>
+      <column name="SourceData" type="field" hidden="0" width="-1"/>
+      <column name="SourceOrig" type="field" hidden="0" width="-1"/>
+      <column name="SourceFeat" type="field" hidden="0" width="-1"/>
+      <column name="LoadDate" type="field" hidden="0" width="-1"/>
+      <column name="AreaSqKm" type="field" hidden="0" width="-1"/>
+      <column name="AreaAcres" type="field" hidden="0" width="-1"/>
+      <column name="GNIS_ID" type="field" hidden="0" width="-1"/>
+      <column name="Name" type="field" hidden="0" width="-1"/>
+      <column name="States" type="field" hidden="0" width="-1"/>
+      <column name="Shape_Leng" type="field" hidden="0" width="-1"/>
+      <column name="Shape_Area" type="field" hidden="0" width="-1"/>
+      <column type="actions" hidden="1" width="-1"/>
+      <column name="HUC6" type="field" hidden="0" width="-1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <storedexpressions/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>generatedlayout</editorlayout>
+  <editable>
+    <field name="AreaAcres" editable="1"/>
+    <field name="AreaSqKm" editable="1"/>
+    <field name="GNIS_ID" editable="1"/>
+    <field name="HUC10" editable="1"/>
+    <field name="HUC6" editable="1"/>
+    <field name="HUC8" editable="1"/>
+    <field name="HUMod" editable="1"/>
+    <field name="HUType" editable="1"/>
+    <field name="LoadDate" editable="1"/>
+    <field name="MetaSource" editable="1"/>
+    <field name="Name" editable="1"/>
+    <field name="Shape_Area" editable="1"/>
+    <field name="Shape_Leng" editable="1"/>
+    <field name="SourceData" editable="1"/>
+    <field name="SourceFeat" editable="1"/>
+    <field name="SourceOrig" editable="1"/>
+    <field name="States" editable="1"/>
+    <field name="TNMID" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="AreaAcres" labelOnTop="0"/>
+    <field name="AreaSqKm" labelOnTop="0"/>
+    <field name="GNIS_ID" labelOnTop="0"/>
+    <field name="HUC10" labelOnTop="0"/>
+    <field name="HUC6" labelOnTop="0"/>
+    <field name="HUC8" labelOnTop="0"/>
+    <field name="HUMod" labelOnTop="0"/>
+    <field name="HUType" labelOnTop="0"/>
+    <field name="LoadDate" labelOnTop="0"/>
+    <field name="MetaSource" labelOnTop="0"/>
+    <field name="Name" labelOnTop="0"/>
+    <field name="Shape_Area" labelOnTop="0"/>
+    <field name="Shape_Leng" labelOnTop="0"/>
+    <field name="SourceData" labelOnTop="0"/>
+    <field name="SourceFeat" labelOnTop="0"/>
+    <field name="SourceOrig" labelOnTop="0"/>
+    <field name="States" labelOnTop="0"/>
+    <field name="TNMID" labelOnTop="0"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>Name</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/Symbology/qgis/RSContext/wbdhu8.qml
+++ b/Symbology/qgis/RSContext/wbdhu8.qml
@@ -1,0 +1,438 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis simplifyDrawingHints="1" version="3.12.1-București" labelsEnabled="1" simplifyMaxScale="1" simplifyLocal="1" readOnly="0" maxScale="0" simplifyAlgorithm="0" simplifyDrawingTol="1" styleCategories="AllStyleCategories" minScale="100000000" hasScaleBasedVisibilityFlag="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" enableorderby="0">
+    <symbols>
+      <symbol name="0" type="fill" clip_to_extent="1" force_rhr="0" alpha="1">
+        <layer enabled="1" locked="0" class="SimpleFill" pass="0">
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="190,207,80,0" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="227,26,28,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="1.75" k="outline_width"/>
+          <prop v="Pixel" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style fontItalic="0" fontWordSpacing="0" namedStyle="Regular" fontCapitals="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" multilineHeight="1" fontSize="10" isExpression="1" fontKerning="1" fieldName=" &quot;Name&quot;  +  '\n'  +   &quot;HUC8&quot; " textOrientation="horizontal" fontUnderline="0" fontStrikeout="0" useSubstitutions="0" fontSizeUnit="Point" fontFamily="MS Shell Dlg 2" textOpacity="1" textColor="255,255,255,255" fontWeight="50" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0">
+        <text-buffer bufferColor="255,255,255,255" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="128" bufferOpacity="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferSizeUnits="MM"/>
+        <text-mask maskEnabled="1" maskType="0" maskJoinStyle="128" maskSize="1.5" maskSizeUnits="MM" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1"/>
+        <background shapeBorderColor="128,128,128,255" shapeBlendMode="0" shapeOffsetUnit="MM" shapeBorderWidthUnit="MM" shapeType="0" shapeDraw="0" shapeSVGFile="" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeSizeUnit="MM" shapeRotation="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeJoinStyle="64" shapeOpacity="1" shapeRotationType="0" shapeRadiiUnit="MM" shapeOffsetY="0" shapeOffsetX="0" shapeFillColor="255,255,255,255" shapeSizeX="0" shapeSizeType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0">
+          <symbol name="markerSymbol" type="marker" clip_to_extent="1" force_rhr="0" alpha="1">
+            <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
+              <prop v="0" k="angle"/>
+              <prop v="255,158,23,255" k="color"/>
+              <prop v="1" k="horizontal_anchor_point"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="circle" k="name"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="35,35,35,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0" k="outline_width"/>
+              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="diameter" k="scale_method"/>
+              <prop v="2" k="size"/>
+              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+              <prop v="MM" k="size_unit"/>
+              <prop v="1" k="vertical_anchor_point"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowOpacity="0.7" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowOffsetAngle="135" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetDist="1" shadowUnder="0" shadowRadiusUnit="MM" shadowOffsetUnit="MM" shadowOffsetGlobal="1" shadowBlendMode="6" shadowDraw="1"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </dd_properties>
+        <substitutions/>
+      </text-style>
+      <text-format autoWrapLength="0" addDirectionSymbol="0" decimals="3" useMaxLineLengthForAutoWrap="1" multilineAlign="1" formatNumbers="0" wrapChar="" rightDirectionSymbol=">" placeDirectionSymbol="0" leftDirectionSymbol="&lt;" reverseDirectionSymbol="0" plussign="0"/>
+      <placement xOffset="0" overrunDistance="0" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" priority="5" geometryGenerator="" repeatDistanceUnits="MM" geometryGeneratorEnabled="0" distUnits="MM" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" fitInPolygonOnly="0" placementFlags="10" preserveRotation="1" centroidInside="0" overrunDistanceUnit="MM" layerType="PolygonGeometry" dist="0" placement="0" maxCurvedCharAngleOut="-25" offsetUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" rotationAngle="0" quadOffset="4" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" centroidWhole="0"/>
+      <rendering obstacleFactor="1" obstacle="1" minFeatureSize="0" labelPerPart="0" drawLabels="1" zIndex="0" displayAll="0" scaleMin="0" fontMaxPixelSize="10000" obstacleType="1" maxNumLabels="2000" limitNumLabels="0" mergeLines="0" scaleVisibility="0" upsidedownLabels="0" scaleMax="0" fontLimitPixelSize="0" fontMinPixelSize="3"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option name="name" value="" type="QString"/>
+          <Option name="properties"/>
+          <Option name="type" value="collection" type="QString"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+          <Option name="ddProperties" type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+          <Option name="drawToAllParts" value="false" type="bool"/>
+          <Option name="enabled" value="1" type="QString"/>
+          <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot; alpha=&quot;1&quot;>&lt;layer enabled=&quot;1&quot; locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+          <Option name="minLength" value="0" type="double"/>
+          <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="minLengthUnit" value="MM" type="QString"/>
+          <Option name="offsetFromAnchor" value="0" type="double"/>
+          <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+          <Option name="offsetFromLabel" value="0" type="double"/>
+          <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
+  <customproperties>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+    <DiagramCategory sizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" diagramOrientation="Up" showAxis="1" direction="0" labelPlacementMethod="XHeight" minimumSize="0" height="15" maxScaleDenominator="1e+08" width="15" spacingUnitScale="3x:0,0,0,0,0,0" scaleDependency="Area" lineSizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" penAlpha="255" spacingUnit="MM" backgroundAlpha="255" barWidth="5" backgroundColor="#ffffff" penWidth="0" rotationOffset="270" enabled="0" spacing="5" opacity="1" scaleBasedVisibility="0" sizeType="MM" penColor="#000000">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <axisSymbol>
+        <symbol name="" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
+          <layer enabled="1" locked="0" class="SimpleLine" pass="0">
+            <prop v="square" k="capstyle"/>
+            <prop v="5;2" k="customdash"/>
+            <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+            <prop v="MM" k="customdash_unit"/>
+            <prop v="0" k="draw_inside_polygon"/>
+            <prop v="bevel" k="joinstyle"/>
+            <prop v="35,35,35,255" k="line_color"/>
+            <prop v="solid" k="line_style"/>
+            <prop v="0.26" k="line_width"/>
+            <prop v="MM" k="line_width_unit"/>
+            <prop v="0" k="offset"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="0" k="ring_filter"/>
+            <prop v="0" k="use_custom_dash"/>
+            <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </axisSymbol>
+    </DiagramCategory>
+  </SingleCategoryDiagramRenderer>
+  <DiagramLayerSettings obstacle="0" placement="1" zIndex="0" linePlacementFlags="18" dist="0" showAll="1" priority="0">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration type="Map">
+      <Option name="QgsGeometryGapCheck" type="Map">
+        <Option name="allowedGapsBuffer" value="0" type="double"/>
+        <Option name="allowedGapsEnabled" value="false" type="bool"/>
+        <Option name="allowedGapsLayer" value="" type="QString"/>
+      </Option>
+    </checkConfiguration>
+  </geometryOptions>
+  <referencedLayers/>
+  <referencingLayers/>
+  <fieldConfiguration>
+    <field name="TNMID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="MetaSource">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceData">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceOrig">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="SourceFeat">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="LoadDate">
+      <editWidget type="DateTime">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="AreaSqKm">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="AreaAcres">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="GNIS_ID">
+      <editWidget type="Range">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="States">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="HUC8">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Shape_Leng">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Shape_Area">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="TNMID" name="" index="0"/>
+    <alias field="MetaSource" name="" index="1"/>
+    <alias field="SourceData" name="" index="2"/>
+    <alias field="SourceOrig" name="" index="3"/>
+    <alias field="SourceFeat" name="" index="4"/>
+    <alias field="LoadDate" name="" index="5"/>
+    <alias field="AreaSqKm" name="" index="6"/>
+    <alias field="AreaAcres" name="" index="7"/>
+    <alias field="GNIS_ID" name="" index="8"/>
+    <alias field="Name" name="" index="9"/>
+    <alias field="States" name="" index="10"/>
+    <alias field="HUC8" name="" index="11"/>
+    <alias field="Shape_Leng" name="" index="12"/>
+    <alias field="Shape_Area" name="" index="13"/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default field="TNMID" expression="" applyOnUpdate="0"/>
+    <default field="MetaSource" expression="" applyOnUpdate="0"/>
+    <default field="SourceData" expression="" applyOnUpdate="0"/>
+    <default field="SourceOrig" expression="" applyOnUpdate="0"/>
+    <default field="SourceFeat" expression="" applyOnUpdate="0"/>
+    <default field="LoadDate" expression="" applyOnUpdate="0"/>
+    <default field="AreaSqKm" expression="" applyOnUpdate="0"/>
+    <default field="AreaAcres" expression="" applyOnUpdate="0"/>
+    <default field="GNIS_ID" expression="" applyOnUpdate="0"/>
+    <default field="Name" expression="" applyOnUpdate="0"/>
+    <default field="States" expression="" applyOnUpdate="0"/>
+    <default field="HUC8" expression="" applyOnUpdate="0"/>
+    <default field="Shape_Leng" expression="" applyOnUpdate="0"/>
+    <default field="Shape_Area" expression="" applyOnUpdate="0"/>
+  </defaults>
+  <constraints>
+    <constraint field="TNMID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="MetaSource" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceData" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceOrig" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="SourceFeat" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="LoadDate" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="AreaSqKm" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="AreaAcres" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="GNIS_ID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Name" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="States" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="HUC8" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Shape_Leng" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Shape_Area" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint field="TNMID" exp="" desc=""/>
+    <constraint field="MetaSource" exp="" desc=""/>
+    <constraint field="SourceData" exp="" desc=""/>
+    <constraint field="SourceOrig" exp="" desc=""/>
+    <constraint field="SourceFeat" exp="" desc=""/>
+    <constraint field="LoadDate" exp="" desc=""/>
+    <constraint field="AreaSqKm" exp="" desc=""/>
+    <constraint field="AreaAcres" exp="" desc=""/>
+    <constraint field="GNIS_ID" exp="" desc=""/>
+    <constraint field="Name" exp="" desc=""/>
+    <constraint field="States" exp="" desc=""/>
+    <constraint field="HUC8" exp="" desc=""/>
+    <constraint field="Shape_Leng" exp="" desc=""/>
+    <constraint field="Shape_Area" exp="" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+    <columns>
+      <column name="TNMID" type="field" hidden="0" width="-1"/>
+      <column name="MetaSource" type="field" hidden="0" width="-1"/>
+      <column name="SourceData" type="field" hidden="0" width="-1"/>
+      <column name="SourceOrig" type="field" hidden="0" width="-1"/>
+      <column name="SourceFeat" type="field" hidden="0" width="-1"/>
+      <column name="LoadDate" type="field" hidden="0" width="-1"/>
+      <column name="AreaSqKm" type="field" hidden="0" width="-1"/>
+      <column name="AreaAcres" type="field" hidden="0" width="-1"/>
+      <column name="GNIS_ID" type="field" hidden="0" width="-1"/>
+      <column name="Name" type="field" hidden="0" width="-1"/>
+      <column name="States" type="field" hidden="0" width="-1"/>
+      <column name="Shape_Leng" type="field" hidden="0" width="-1"/>
+      <column name="Shape_Area" type="field" hidden="0" width="-1"/>
+      <column type="actions" hidden="1" width="-1"/>
+      <column name="HUC8" type="field" hidden="0" width="-1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <storedexpressions/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>generatedlayout</editorlayout>
+  <editable>
+    <field name="AreaAcres" editable="1"/>
+    <field name="AreaSqKm" editable="1"/>
+    <field name="GNIS_ID" editable="1"/>
+    <field name="HUC10" editable="1"/>
+    <field name="HUC8" editable="1"/>
+    <field name="HUMod" editable="1"/>
+    <field name="HUType" editable="1"/>
+    <field name="LoadDate" editable="1"/>
+    <field name="MetaSource" editable="1"/>
+    <field name="Name" editable="1"/>
+    <field name="Shape_Area" editable="1"/>
+    <field name="Shape_Leng" editable="1"/>
+    <field name="SourceData" editable="1"/>
+    <field name="SourceFeat" editable="1"/>
+    <field name="SourceOrig" editable="1"/>
+    <field name="States" editable="1"/>
+    <field name="TNMID" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="AreaAcres" labelOnTop="0"/>
+    <field name="AreaSqKm" labelOnTop="0"/>
+    <field name="GNIS_ID" labelOnTop="0"/>
+    <field name="HUC10" labelOnTop="0"/>
+    <field name="HUC8" labelOnTop="0"/>
+    <field name="HUMod" labelOnTop="0"/>
+    <field name="HUType" labelOnTop="0"/>
+    <field name="LoadDate" labelOnTop="0"/>
+    <field name="MetaSource" labelOnTop="0"/>
+    <field name="Name" labelOnTop="0"/>
+    <field name="Shape_Area" labelOnTop="0"/>
+    <field name="Shape_Leng" labelOnTop="0"/>
+    <field name="SourceData" labelOnTop="0"/>
+    <field name="SourceFeat" labelOnTop="0"/>
+    <field name="SourceOrig" labelOnTop="0"/>
+    <field name="States" labelOnTop="0"/>
+    <field name="TNMID" labelOnTop="0"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>Name</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/Symbology/qgis/Shared/nhdperrenial.qml
+++ b/Symbology/qgis/Shared/nhdperrenial.qml
@@ -1,71 +1,35 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="3.18.1-Zürich" styleCategories="LayerConfiguration|Symbology|Labeling|Rendering|Legend" labelsEnabled="0" simplifyLocal="1" simplifyAlgorithm="0" minScale="100000000" simplifyDrawingHints="1" readOnly="0" hasScaleBasedVisibilityFlag="0" simplifyDrawingTol="1" maxScale="0" simplifyMaxScale="1">
+<qgis simplifyDrawingHints="1" version="3.12.1-București" labelsEnabled="1" simplifyMaxScale="1" simplifyLocal="1" readOnly="0" maxScale="0" simplifyAlgorithm="0" simplifyDrawingTol="1" styleCategories="AllStyleCategories" minScale="100000000" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
-    <Private>0</Private>
   </flags>
-  <renderer-v2 forceraster="0" attr="FCode" enableorderby="0" symbollevels="0" type="categorizedSymbol">
+  <renderer-v2 symbollevels="0" attr="FCode" type="categorizedSymbol" forceraster="0" enableorderby="0">
     <categories>
-      <category render="true" value="46006" label="Perennial" symbol="0"/>
-      <category render="true" value="55800" label="Artificial Path" symbol="1"/>
-      <category render="true" value="33400" label="Connector" symbol="2"/>
+      <category value="46006" label="Perennial" symbol="0" render="true"/>
+      <category value="55800" label="Artificial Path" symbol="1" render="true"/>
+      <category value="33400" label="Connector" symbol="2" render="true"/>
     </categories>
     <symbols>
-      <symbol alpha="1" name="0" force_rhr="0" type="line" clip_to_extent="1">
-        <data_defined_properties>
-          <Option type="Map">
-            <Option name="name" value="" type="QString"/>
-            <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
-          </Option>
-        </data_defined_properties>
-        <layer class="SimpleLine" enabled="1" pass="0" locked="0">
-          <Option type="Map">
-            <Option name="align_dash_pattern" value="0" type="QString"/>
-            <Option name="capstyle" value="square" type="QString"/>
-            <Option name="customdash" value="5;2" type="QString"/>
-            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-            <Option name="customdash_unit" value="MM" type="QString"/>
-            <Option name="dash_pattern_offset" value="0" type="QString"/>
-            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
-            <Option name="draw_inside_polygon" value="0" type="QString"/>
-            <Option name="joinstyle" value="bevel" type="QString"/>
-            <Option name="line_color" value="0,76,168,255" type="QString"/>
-            <Option name="line_style" value="solid" type="QString"/>
-            <Option name="line_width" value="1" type="QString"/>
-            <Option name="line_width_unit" value="MM" type="QString"/>
-            <Option name="offset" value="0" type="QString"/>
-            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-            <Option name="offset_unit" value="MM" type="QString"/>
-            <Option name="ring_filter" value="0" type="QString"/>
-            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
-            <Option name="use_custom_dash" value="0" type="QString"/>
-            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-          </Option>
-          <prop k="align_dash_pattern" v="0"/>
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="dash_pattern_offset" v="0"/>
-          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="dash_pattern_offset_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="0,76,168,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="1"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="tweak_dash_pattern_on_corners" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+      <symbol name="0" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
+        <layer enabled="1" locked="0" class="SimpleLine" pass="0">
+          <prop v="square" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="Pixel" k="customdash_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,76,168,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="1" k="line_width"/>
+          <prop v="Pixel" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="Pixel" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
               <Option name="name" value="" type="QString"/>
@@ -75,59 +39,24 @@
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" name="1" force_rhr="0" type="line" clip_to_extent="1">
-        <data_defined_properties>
-          <Option type="Map">
-            <Option name="name" value="" type="QString"/>
-            <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
-          </Option>
-        </data_defined_properties>
-        <layer class="SimpleLine" enabled="1" pass="0" locked="0">
-          <Option type="Map">
-            <Option name="align_dash_pattern" value="0" type="QString"/>
-            <Option name="capstyle" value="square" type="QString"/>
-            <Option name="customdash" value="5;2" type="QString"/>
-            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-            <Option name="customdash_unit" value="MM" type="QString"/>
-            <Option name="dash_pattern_offset" value="0" type="QString"/>
-            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
-            <Option name="draw_inside_polygon" value="0" type="QString"/>
-            <Option name="joinstyle" value="bevel" type="QString"/>
-            <Option name="line_color" value="0,77,168,255" type="QString"/>
-            <Option name="line_style" value="solid" type="QString"/>
-            <Option name="line_width" value="0.5" type="QString"/>
-            <Option name="line_width_unit" value="MM" type="QString"/>
-            <Option name="offset" value="0" type="QString"/>
-            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-            <Option name="offset_unit" value="MM" type="QString"/>
-            <Option name="ring_filter" value="0" type="QString"/>
-            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
-            <Option name="use_custom_dash" value="0" type="QString"/>
-            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-          </Option>
-          <prop k="align_dash_pattern" v="0"/>
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="dash_pattern_offset" v="0"/>
-          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="dash_pattern_offset_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="0,77,168,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.5"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="tweak_dash_pattern_on_corners" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+      <symbol name="1" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
+        <layer enabled="1" locked="0" class="SimpleLine" pass="0">
+          <prop v="square" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="Pixel" k="customdash_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,77,168,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="0.5" k="line_width"/>
+          <prop v="Pixel" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="Pixel" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
               <Option name="name" value="" type="QString"/>
@@ -137,59 +66,24 @@
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" name="2" force_rhr="0" type="line" clip_to_extent="1">
-        <data_defined_properties>
-          <Option type="Map">
-            <Option name="name" value="" type="QString"/>
-            <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
-          </Option>
-        </data_defined_properties>
-        <layer class="SimpleLine" enabled="1" pass="0" locked="0">
-          <Option type="Map">
-            <Option name="align_dash_pattern" value="0" type="QString"/>
-            <Option name="capstyle" value="square" type="QString"/>
-            <Option name="customdash" value="5;2" type="QString"/>
-            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-            <Option name="customdash_unit" value="MM" type="QString"/>
-            <Option name="dash_pattern_offset" value="0" type="QString"/>
-            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
-            <Option name="draw_inside_polygon" value="0" type="QString"/>
-            <Option name="joinstyle" value="bevel" type="QString"/>
-            <Option name="line_color" value="0,38,115,255" type="QString"/>
-            <Option name="line_style" value="solid" type="QString"/>
-            <Option name="line_width" value="1" type="QString"/>
-            <Option name="line_width_unit" value="MM" type="QString"/>
-            <Option name="offset" value="0" type="QString"/>
-            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-            <Option name="offset_unit" value="MM" type="QString"/>
-            <Option name="ring_filter" value="0" type="QString"/>
-            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
-            <Option name="use_custom_dash" value="0" type="QString"/>
-            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-          </Option>
-          <prop k="align_dash_pattern" v="0"/>
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="dash_pattern_offset" v="0"/>
-          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="dash_pattern_offset_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="0,38,115,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="1"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="tweak_dash_pattern_on_corners" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+      <symbol name="2" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
+        <layer enabled="1" locked="0" class="SimpleLine" pass="0">
+          <prop v="square" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="Pixel" k="customdash_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,38,115,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="1" k="line_width"/>
+          <prop v="Pixel" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="Pixel" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
               <Option name="name" value="" type="QString"/>
@@ -201,59 +95,24 @@
       </symbol>
     </symbols>
     <source-symbol>
-      <symbol alpha="1" name="0" force_rhr="0" type="line" clip_to_extent="1">
-        <data_defined_properties>
-          <Option type="Map">
-            <Option name="name" value="" type="QString"/>
-            <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
-          </Option>
-        </data_defined_properties>
-        <layer class="SimpleLine" enabled="1" pass="0" locked="0">
-          <Option type="Map">
-            <Option name="align_dash_pattern" value="0" type="QString"/>
-            <Option name="capstyle" value="square" type="QString"/>
-            <Option name="customdash" value="5;2" type="QString"/>
-            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-            <Option name="customdash_unit" value="MM" type="QString"/>
-            <Option name="dash_pattern_offset" value="0" type="QString"/>
-            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
-            <Option name="draw_inside_polygon" value="0" type="QString"/>
-            <Option name="joinstyle" value="bevel" type="QString"/>
-            <Option name="line_color" value="232,113,141,255" type="QString"/>
-            <Option name="line_style" value="solid" type="QString"/>
-            <Option name="line_width" value="0.26" type="QString"/>
-            <Option name="line_width_unit" value="MM" type="QString"/>
-            <Option name="offset" value="0" type="QString"/>
-            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-            <Option name="offset_unit" value="MM" type="QString"/>
-            <Option name="ring_filter" value="0" type="QString"/>
-            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
-            <Option name="use_custom_dash" value="0" type="QString"/>
-            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-          </Option>
-          <prop k="align_dash_pattern" v="0"/>
-          <prop k="capstyle" v="square"/>
-          <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="dash_pattern_offset" v="0"/>
-          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="dash_pattern_offset_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="232,113,141,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.26"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="tweak_dash_pattern_on_corners" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+      <symbol name="0" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
+        <layer enabled="1" locked="0" class="SimpleLine" pass="0">
+          <prop v="square" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="232,113,141,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="0.26" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
               <Option name="name" value="" type="QString"/>
@@ -264,16 +123,541 @@
         </layer>
       </symbol>
     </source-symbol>
-    <colorramp name="[source]" type="randomcolors">
-      <Option/>
-    </colorramp>
     <rotation/>
     <sizescale/>
   </renderer-v2>
+  <labeling type="rule-based">
+    <rules key="{9e4dec42-0f8e-452a-a9ef-daf67ab77f8a}">
+      <rule filter=" &quot;GNIS_Name&quot; " scalemindenom="2500" description="HUC 8" scalemaxdenom="25000" key="{5686586a-fbf3-4336-8ef9-d4fb4ce1b529}">
+        <settings calloutType="simple">
+          <text-style fontItalic="0" fontWordSpacing="0" namedStyle="Regular" fontCapitals="0" fontLetterSpacing="0" previewBkgrdColor="255,255,255,255" multilineHeight="1" fontSize="9" isExpression="0" fontKerning="1" fieldName="GNIS_Name" textOrientation="horizontal" fontUnderline="0" fontStrikeout="0" useSubstitutions="0" fontSizeUnit="Point" fontFamily="Arial Narrow" textOpacity="1" textColor="255,255,255,255" fontWeight="50" fontSizeMapUnitScale="3x:0,0,0,0,0,0" blendMode="0">
+            <text-buffer bufferColor="255,255,255,255" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="128" bufferOpacity="1" bufferBlendMode="0" bufferDraw="0" bufferNoFill="1" bufferSizeUnits="MM"/>
+            <text-mask maskEnabled="0" maskType="0" maskJoinStyle="128" maskSize="1.5" maskSizeUnits="MM" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1"/>
+            <background shapeBorderColor="128,128,128,255" shapeBlendMode="0" shapeOffsetUnit="MM" shapeBorderWidthUnit="MM" shapeType="0" shapeDraw="0" shapeSVGFile="" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeSizeUnit="MM" shapeRotation="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeY="0" shapeBorderWidth="0" shapeRadiiY="0" shapeJoinStyle="64" shapeOpacity="1" shapeRotationType="0" shapeRadiiUnit="MM" shapeOffsetY="0" shapeOffsetX="0" shapeFillColor="255,255,255,255" shapeSizeX="0" shapeSizeType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0">
+              <symbol name="markerSymbol" type="marker" clip_to_extent="1" force_rhr="0" alpha="1">
+                <layer enabled="1" locked="0" class="SimpleMarker" pass="0">
+                  <prop v="0" k="angle"/>
+                  <prop v="190,207,80,255" k="color"/>
+                  <prop v="1" k="horizontal_anchor_point"/>
+                  <prop v="bevel" k="joinstyle"/>
+                  <prop v="circle" k="name"/>
+                  <prop v="0,0" k="offset"/>
+                  <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+                  <prop v="MM" k="offset_unit"/>
+                  <prop v="35,35,35,255" k="outline_color"/>
+                  <prop v="solid" k="outline_style"/>
+                  <prop v="0" k="outline_width"/>
+                  <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+                  <prop v="MM" k="outline_width_unit"/>
+                  <prop v="diameter" k="scale_method"/>
+                  <prop v="2" k="size"/>
+                  <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+                  <prop v="MM" k="size_unit"/>
+                  <prop v="1" k="vertical_anchor_point"/>
+                  <data_defined_properties>
+                    <Option type="Map">
+                      <Option name="name" value="" type="QString"/>
+                      <Option name="properties"/>
+                      <Option name="type" value="collection" type="QString"/>
+                    </Option>
+                  </data_defined_properties>
+                </layer>
+              </symbol>
+            </background>
+            <shadow shadowOpacity="0.7" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowOffsetAngle="135" shadowRadiusAlphaOnly="0" shadowColor="0,0,0,255" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetDist="1" shadowUnder="0" shadowRadiusUnit="Pixel" shadowOffsetUnit="Pixel" shadowOffsetGlobal="1" shadowBlendMode="6" shadowDraw="1"/>
+            <dd_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </dd_properties>
+            <substitutions/>
+          </text-style>
+          <text-format autoWrapLength="0" addDirectionSymbol="0" decimals="3" useMaxLineLengthForAutoWrap="1" multilineAlign="0" formatNumbers="0" wrapChar="" rightDirectionSymbol=">" placeDirectionSymbol="0" leftDirectionSymbol="&lt;" reverseDirectionSymbol="0" plussign="0"/>
+          <placement xOffset="0" overrunDistance="0" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" priority="5" geometryGenerator="" repeatDistanceUnits="MM" geometryGeneratorEnabled="0" distUnits="MM" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" repeatDistance="0" fitInPolygonOnly="0" placementFlags="10" preserveRotation="1" centroidInside="0" overrunDistanceUnit="MM" layerType="LineGeometry" dist="0" placement="3" maxCurvedCharAngleOut="-25" offsetUnits="MM" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" rotationAngle="0" quadOffset="4" maxCurvedCharAngleIn="25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" centroidWhole="0"/>
+          <rendering obstacleFactor="1" obstacle="1" minFeatureSize="0" labelPerPart="0" drawLabels="1" zIndex="0" displayAll="0" scaleMin="0" fontMaxPixelSize="10000" obstacleType="1" maxNumLabels="2000" limitNumLabels="0" mergeLines="0" scaleVisibility="0" upsidedownLabels="0" scaleMax="0" fontLimitPixelSize="0" fontMinPixelSize="3"/>
+          <dd_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </dd_properties>
+          <callout type="simple">
+            <Option type="Map">
+              <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+              <Option name="ddProperties" type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+              <Option name="drawToAllParts" value="false" type="bool"/>
+              <Option name="enabled" value="0" type="QString"/>
+              <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot; alpha=&quot;1&quot;>&lt;layer enabled=&quot;1&quot; locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+              <Option name="minLength" value="0" type="double"/>
+              <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="minLengthUnit" value="MM" type="QString"/>
+              <Option name="offsetFromAnchor" value="0" type="double"/>
+              <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+              <Option name="offsetFromLabel" value="0" type="double"/>
+              <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
+            </Option>
+          </callout>
+        </settings>
+      </rule>
+    </rules>
+  </labeling>
+  <customproperties>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>1</layerOpacity>
-  <legend type="default-vector"/>
-  <previewExpression>"GNIS_Name"</previewExpression>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+    <DiagramCategory sizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" diagramOrientation="Up" showAxis="1" direction="0" labelPlacementMethod="XHeight" minimumSize="0" height="15" maxScaleDenominator="1e+08" width="15" spacingUnitScale="3x:0,0,0,0,0,0" scaleDependency="Area" lineSizeType="MM" lineSizeScale="3x:0,0,0,0,0,0" penAlpha="255" spacingUnit="MM" backgroundAlpha="255" barWidth="5" backgroundColor="#ffffff" penWidth="0" rotationOffset="270" enabled="0" spacing="5" opacity="1" scaleBasedVisibility="0" sizeType="MM" penColor="#000000">
+      <fontProperties style="" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
+      <axisSymbol>
+        <symbol name="" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
+          <layer enabled="1" locked="0" class="SimpleLine" pass="0">
+            <prop v="square" k="capstyle"/>
+            <prop v="5;2" k="customdash"/>
+            <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+            <prop v="MM" k="customdash_unit"/>
+            <prop v="0" k="draw_inside_polygon"/>
+            <prop v="bevel" k="joinstyle"/>
+            <prop v="35,35,35,255" k="line_color"/>
+            <prop v="solid" k="line_style"/>
+            <prop v="0.26" k="line_width"/>
+            <prop v="MM" k="line_width_unit"/>
+            <prop v="0" k="offset"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="0" k="ring_filter"/>
+            <prop v="0" k="use_custom_dash"/>
+            <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </axisSymbol>
+    </DiagramCategory>
+  </SingleCategoryDiagramRenderer>
+  <DiagramLayerSettings obstacle="0" placement="2" zIndex="0" linePlacementFlags="18" dist="0" showAll="1" priority="0">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <referencedLayers/>
+  <referencingLayers/>
+  <fieldConfiguration>
+    <field name="Permanent_">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="FDate">
+      <editWidget type="DateTime">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Resolution">
+      <editWidget type="Range">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="GNIS_ID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="GNIS_Name">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="LengthKM">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ReachCode">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="FlowDir">
+      <editWidget type="Range">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="WBArea_Per">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="FType">
+      <editWidget type="Range">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="FCode">
+      <editWidget type="Range">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="MainPath">
+      <editWidget type="Range">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="InNetwork">
+      <editWidget type="Range">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Visibility">
+      <editWidget type="Range">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Shape_Leng">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="NHDPlusID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="VPUID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Enabled">
+      <editWidget type="Range">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="AreaSqKm">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="TotDASqKm">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Slope">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="MaxElevSmo">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="MInElevSmo">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="BFwidth">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="Permanent_" name="" index="0"/>
+    <alias field="FDate" name="" index="1"/>
+    <alias field="Resolution" name="" index="2"/>
+    <alias field="GNIS_ID" name="" index="3"/>
+    <alias field="GNIS_Name" name="" index="4"/>
+    <alias field="LengthKM" name="" index="5"/>
+    <alias field="ReachCode" name="" index="6"/>
+    <alias field="FlowDir" name="" index="7"/>
+    <alias field="WBArea_Per" name="" index="8"/>
+    <alias field="FType" name="" index="9"/>
+    <alias field="FCode" name="" index="10"/>
+    <alias field="MainPath" name="" index="11"/>
+    <alias field="InNetwork" name="" index="12"/>
+    <alias field="Visibility" name="" index="13"/>
+    <alias field="Shape_Leng" name="" index="14"/>
+    <alias field="NHDPlusID" name="" index="15"/>
+    <alias field="VPUID" name="" index="16"/>
+    <alias field="Enabled" name="" index="17"/>
+    <alias field="AreaSqKm" name="" index="18"/>
+    <alias field="TotDASqKm" name="" index="19"/>
+    <alias field="Slope" name="" index="20"/>
+    <alias field="MaxElevSmo" name="" index="21"/>
+    <alias field="MInElevSmo" name="" index="22"/>
+    <alias field="BFwidth" name="" index="23"/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default field="Permanent_" expression="" applyOnUpdate="0"/>
+    <default field="FDate" expression="" applyOnUpdate="0"/>
+    <default field="Resolution" expression="" applyOnUpdate="0"/>
+    <default field="GNIS_ID" expression="" applyOnUpdate="0"/>
+    <default field="GNIS_Name" expression="" applyOnUpdate="0"/>
+    <default field="LengthKM" expression="" applyOnUpdate="0"/>
+    <default field="ReachCode" expression="" applyOnUpdate="0"/>
+    <default field="FlowDir" expression="" applyOnUpdate="0"/>
+    <default field="WBArea_Per" expression="" applyOnUpdate="0"/>
+    <default field="FType" expression="" applyOnUpdate="0"/>
+    <default field="FCode" expression="" applyOnUpdate="0"/>
+    <default field="MainPath" expression="" applyOnUpdate="0"/>
+    <default field="InNetwork" expression="" applyOnUpdate="0"/>
+    <default field="Visibility" expression="" applyOnUpdate="0"/>
+    <default field="Shape_Leng" expression="" applyOnUpdate="0"/>
+    <default field="NHDPlusID" expression="" applyOnUpdate="0"/>
+    <default field="VPUID" expression="" applyOnUpdate="0"/>
+    <default field="Enabled" expression="" applyOnUpdate="0"/>
+    <default field="AreaSqKm" expression="" applyOnUpdate="0"/>
+    <default field="TotDASqKm" expression="" applyOnUpdate="0"/>
+    <default field="Slope" expression="" applyOnUpdate="0"/>
+    <default field="MaxElevSmo" expression="" applyOnUpdate="0"/>
+    <default field="MInElevSmo" expression="" applyOnUpdate="0"/>
+    <default field="BFwidth" expression="" applyOnUpdate="0"/>
+  </defaults>
+  <constraints>
+    <constraint field="Permanent_" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="FDate" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Resolution" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="GNIS_ID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="GNIS_Name" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="LengthKM" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="ReachCode" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="FlowDir" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="WBArea_Per" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="FType" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="FCode" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="MainPath" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="InNetwork" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Visibility" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Shape_Leng" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="NHDPlusID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="VPUID" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Enabled" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="AreaSqKm" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="TotDASqKm" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="Slope" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="MaxElevSmo" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="MInElevSmo" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+    <constraint field="BFwidth" notnull_strength="0" exp_strength="0" constraints="0" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint field="Permanent_" exp="" desc=""/>
+    <constraint field="FDate" exp="" desc=""/>
+    <constraint field="Resolution" exp="" desc=""/>
+    <constraint field="GNIS_ID" exp="" desc=""/>
+    <constraint field="GNIS_Name" exp="" desc=""/>
+    <constraint field="LengthKM" exp="" desc=""/>
+    <constraint field="ReachCode" exp="" desc=""/>
+    <constraint field="FlowDir" exp="" desc=""/>
+    <constraint field="WBArea_Per" exp="" desc=""/>
+    <constraint field="FType" exp="" desc=""/>
+    <constraint field="FCode" exp="" desc=""/>
+    <constraint field="MainPath" exp="" desc=""/>
+    <constraint field="InNetwork" exp="" desc=""/>
+    <constraint field="Visibility" exp="" desc=""/>
+    <constraint field="Shape_Leng" exp="" desc=""/>
+    <constraint field="NHDPlusID" exp="" desc=""/>
+    <constraint field="VPUID" exp="" desc=""/>
+    <constraint field="Enabled" exp="" desc=""/>
+    <constraint field="AreaSqKm" exp="" desc=""/>
+    <constraint field="TotDASqKm" exp="" desc=""/>
+    <constraint field="Slope" exp="" desc=""/>
+    <constraint field="MaxElevSmo" exp="" desc=""/>
+    <constraint field="MInElevSmo" exp="" desc=""/>
+    <constraint field="BFwidth" exp="" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+    <columns>
+      <column name="Permanent_" type="field" hidden="0" width="-1"/>
+      <column name="FDate" type="field" hidden="0" width="-1"/>
+      <column name="Resolution" type="field" hidden="0" width="-1"/>
+      <column name="GNIS_ID" type="field" hidden="0" width="-1"/>
+      <column name="GNIS_Name" type="field" hidden="0" width="-1"/>
+      <column name="LengthKM" type="field" hidden="0" width="-1"/>
+      <column name="ReachCode" type="field" hidden="0" width="-1"/>
+      <column name="FlowDir" type="field" hidden="0" width="-1"/>
+      <column name="WBArea_Per" type="field" hidden="0" width="-1"/>
+      <column name="FType" type="field" hidden="0" width="-1"/>
+      <column name="FCode" type="field" hidden="0" width="-1"/>
+      <column name="MainPath" type="field" hidden="0" width="-1"/>
+      <column name="InNetwork" type="field" hidden="0" width="-1"/>
+      <column name="Visibility" type="field" hidden="0" width="-1"/>
+      <column name="Shape_Leng" type="field" hidden="0" width="-1"/>
+      <column name="NHDPlusID" type="field" hidden="0" width="-1"/>
+      <column name="VPUID" type="field" hidden="0" width="-1"/>
+      <column name="Enabled" type="field" hidden="0" width="-1"/>
+      <column name="AreaSqKm" type="field" hidden="0" width="-1"/>
+      <column name="TotDASqKm" type="field" hidden="0" width="-1"/>
+      <column name="Slope" type="field" hidden="0" width="-1"/>
+      <column name="MaxElevSmo" type="field" hidden="0" width="-1"/>
+      <column name="MInElevSmo" type="field" hidden="0" width="-1"/>
+      <column name="BFwidth" type="field" hidden="0" width="-1"/>
+      <column type="actions" hidden="1" width="-1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <storedexpressions/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>generatedlayout</editorlayout>
+  <editable>
+    <field name="AreaSqKm" editable="1"/>
+    <field name="BFwidth" editable="1"/>
+    <field name="Enabled" editable="1"/>
+    <field name="FCode" editable="1"/>
+    <field name="FDate" editable="1"/>
+    <field name="FType" editable="1"/>
+    <field name="FlowDir" editable="1"/>
+    <field name="GNIS_ID" editable="1"/>
+    <field name="GNIS_Name" editable="1"/>
+    <field name="InNetwork" editable="1"/>
+    <field name="LengthKM" editable="1"/>
+    <field name="MInElevSmo" editable="1"/>
+    <field name="MainPath" editable="1"/>
+    <field name="MaxElevSmo" editable="1"/>
+    <field name="NHDPlusID" editable="1"/>
+    <field name="Permanent_" editable="1"/>
+    <field name="ReachCode" editable="1"/>
+    <field name="Resolution" editable="1"/>
+    <field name="Shape_Leng" editable="1"/>
+    <field name="Slope" editable="1"/>
+    <field name="TotDASqKm" editable="1"/>
+    <field name="VPUID" editable="1"/>
+    <field name="Visibility" editable="1"/>
+    <field name="WBArea_Per" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="AreaSqKm" labelOnTop="0"/>
+    <field name="BFwidth" labelOnTop="0"/>
+    <field name="Enabled" labelOnTop="0"/>
+    <field name="FCode" labelOnTop="0"/>
+    <field name="FDate" labelOnTop="0"/>
+    <field name="FType" labelOnTop="0"/>
+    <field name="FlowDir" labelOnTop="0"/>
+    <field name="GNIS_ID" labelOnTop="0"/>
+    <field name="GNIS_Name" labelOnTop="0"/>
+    <field name="InNetwork" labelOnTop="0"/>
+    <field name="LengthKM" labelOnTop="0"/>
+    <field name="MInElevSmo" labelOnTop="0"/>
+    <field name="MainPath" labelOnTop="0"/>
+    <field name="MaxElevSmo" labelOnTop="0"/>
+    <field name="NHDPlusID" labelOnTop="0"/>
+    <field name="Permanent_" labelOnTop="0"/>
+    <field name="ReachCode" labelOnTop="0"/>
+    <field name="Resolution" labelOnTop="0"/>
+    <field name="Shape_Leng" labelOnTop="0"/>
+    <field name="Slope" labelOnTop="0"/>
+    <field name="TotDASqKm" labelOnTop="0"/>
+    <field name="VPUID" labelOnTop="0"/>
+    <field name="Visibility" labelOnTop="0"/>
+    <field name="WBArea_Per" labelOnTop="0"/>
+  </labelOnTop>
+  <widgets/>
+  <previewExpression>GNIS_Name</previewExpression>
+  <mapTip></mapTip>
   <layerGeometryType>1</layerGeometryType>
 </qgis>


### PR DESCRIPTION
I updated the watershed boundaries for our Riverscape Context files.

## HUC 8, 10 and 12s
Down at our watershed scales, we often need to know which HUC12, 10 or 8 we're working in and its helpful to have the names. I used black for the 10 digit outlines to differentiate them, a thinner red for HUC 12 and wider red for HUC 8.
![image](https://user-images.githubusercontent.com/9723905/118600650-86c0cd00-b76e-11eb-9fea-465da61de30f.png)

## HUC 6, 4 and 2s
Regionally, we just need to see the broader boundary, and the name:
![image](https://user-images.githubusercontent.com/9723905/118600947-e323ec80-b76e-11eb-868e-eea799906984.png)

-----
I also updated the Perennial NHD to a thinner width and to usefully show stream names. This is partly to test how well the labels, which _can_ be optionally specified as part of `.qml` work.

![image](https://user-images.githubusercontent.com/9723905/118601088-0e0e4080-b76f-11eb-9357-4da301184f6c.png)


@shelbysawyer and and @lauren-herbine feel free to comment.
