### PR TITLE
Symbology SCHEMA updates for webRAVE

### DIFF
--- a/Symbology/web/Confinement/confinement_buffer.json
+++ b/Symbology/web/Confinement/confinement_buffer.json
@@ -1,13 +1,19 @@
-[
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    [ "hsl(268, 29%, 60%)", "Confinement Buffer" ]
+  ],
+  "layerStyles": [
     {
-        "id": "confinement-buffer-dt9i2g",
-        "type": "fill",
-        "source": "composite",
-        "source-layer": "confinement_buffer-dt9i2g",
-        "layout": {},
-        "paint": {
-            "fill-color": "hsl(268, 29%, 60%)",
-            "fill-outline-color": "#000000"
-        }
+      "id": "confinement-buffer-dt9i2g",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "confinement_buffer-dt9i2g",
+      "layout": {},
+      "paint": {
+        "fill-color": "hsl(268, 29%, 60%)",
+        "fill-outline-color": "#000000"
+      }
     }
-]
+  ]
+}

--- a/Symbology/web/Confinement/confinement_margins.json
+++ b/Symbology/web/Confinement/confinement_margins.json
@@ -1,24 +1,30 @@
-[
-    {
-        "id": "confinement-ratio-3oldrq",
-        "type": "line",
-        "source": "composite",
-        "source-layer": "confinement_ratio-3oldrq",
-        "layout": {},
-        "paint": {
-            "line-color": [
-                "step",
-                ["get", "Confinement_Ratio"],
-                "hsl(116, 57%, 39%)",
-                0.1,
-                "hsl(108, 87%, 59%)",
-                0.5,
-                "hsl(29, 100%, 50%)",
-                0.85,
-                "hsl(8, 100%, 50%)",
-                1.0000000000002822,
-                "hsl(8, 100%, 50%)"
-            ]
+{
+    "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+    "legend": [
+        ["hsl(116, 57%, 39%)", "0.1"],
+        ["hsl(108, 87%, 59%)", "0.5"],
+        ["hsl(29, 100%, 50%)", "0.85"],
+        ["hsl(8, 100%, 50%)", "1.0"]
+    ],
+    "layerStyles": [
+        {
+            "id": "confinement-ratio-3oldrq",
+            "type": "line",
+            "source": "composite",
+            "source-layer": "confinement_ratio-3oldrq",
+            "layout": {},
+            "paint": {
+                "line-color": [
+                    "step",
+                    ["get", "Confinement_Ratio"],
+                    "hsl(116, 57%, 39%)", 0.1,
+                    "hsl(108, 87%, 59%)", 0.5,
+                    "hsl(29, 100%, 50%)", 0.85,
+                    "hsl(8, 100%, 50%)", 1.0,
+                    "hsl(8, 100%, 50%)"
+                ]
+            }
         }
-    }
-]
+    ]
+}
+

--- a/Symbology/web/Confinement/confinement_ratio.json
+++ b/Symbology/web/Confinement/confinement_ratio.json
@@ -1,24 +1,29 @@
-[
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(116, 57%, 39%)", "0.1"],
+    ["hsl(108, 87%, 59%)", "0.5"],
+    ["hsl(29, 100%, 50%)", "0.85"],
+    ["hsl(8, 100%, 50%)", "1.0"]
+  ],
+  "layerStyles": [
     {
-        "id": "confinement-ratio-3oldrq",
-        "type": "line",
-        "source": "composite",
-        "source-layer": "confinement_ratio-3oldrq",
-        "layout": {},
-        "paint": {
-            "line-color": [
-                "step",
-                ["get", "Confinement_Ratio"],
-                "hsl(116, 57%, 39%)",
-                0.1,
-                "hsl(108, 87%, 59%)",
-                0.5,
-                "hsl(29, 100%, 50%)",
-                0.85,
-                "hsl(8, 100%, 50%)",
-                1.0000000000002822,
-                "hsl(8, 100%, 50%)"
-            ]
-        }
+      "id": "confinement-ratio-3oldrq",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "confinement_ratio-3oldrq",
+      "layout": {},
+      "paint": {
+        "line-color": [
+          "step",
+          [ "get", "Confinement_Ratio"],
+          "hsl(116, 57%, 39%)", 0.1,
+          "hsl(108, 87%, 59%)", 0.5,
+          "hsl(29, 100%, 50%)", 0.85,
+          "hsl(8, 100%, 50%)", 1.0,
+          "hsl(8, 100%, 50%)"
+        ]
+      }
     }
-]
+  ]
+}

--- a/Symbology/web/Confinement/confinement_raw.json
+++ b/Symbology/web/Confinement/confinement_raw.json
@@ -1,24 +1,29 @@
-[
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+        ["hsl(8, 100%, 50%)", "Both"],
+        ["hsl(235, 86%, 55%)", "Left"],
+        ["hsl(313, 71%, 39%)", "Right"],
+        [ "hsl(178, 64%, 34%)", "None"]
+  ],
+  "layerStyles": [
     {
-        "id": "confinement-raw-0utorb",
-        "type": "line",
-        "source": "composite",
-        "source-layer": "confinement_raw-0utorb",
-        "layout": {},
-        "paint": {
-            "line-color": [
-                "match",
-                ["get", "Confinement_Type"],
-                ["Both"],
-                "hsl(8, 100%, 50%)",
-                ["Left"],
-                "hsl(235, 86%, 55%)",
-                ["Right"],
-                "hsl(313, 71%, 39%)",
-                ["None"],
-                "hsl(178, 64%, 34%)",
-                "#000000"
-            ]
-        }
+      "id": "confinement-raw-0utorb",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "confinement_raw-0utorb",
+      "layout": {},
+      "paint": {
+        "line-color": [
+          "match",
+          [ "get", "Confinement_Type"],
+          ["Both"],"hsl(8, 100%, 50%)",
+          ["Left"],"hsl(235, 86%, 55%)",
+          ["Right"],"hsl(313, 71%, 39%)",
+          ["None"], "hsl(178, 64%, 34%)",
+          "#000000"
+        ]
+      }
     }
-]
+  ]
+}

--- a/Symbology/web/Confinement/confining_poly.json
+++ b/Symbology/web/Confinement/confining_poly.json
@@ -1,13 +1,19 @@
-[
-    {
-        "id": "confining-poly-3a679s",
-        "type": "fill",
-        "source": "composite",
-        "source-layer": "confining_poly-3a679s",
-        "layout": {},
-        "paint": {
-            "fill-color": "hsl(60, 36%, 59%)",
-            "fill-outline-color": "hsla(0, 0%, 0%, 0)"
+{
+    "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+    "legend": [
+      ["hsl(60, 36%, 59%)", "Confining Polygon"]
+    ],
+    "layerStyles": [
+        {
+            "id": "confining-poly-3a679s",
+            "type": "fill",
+            "source": "composite",
+            "source-layer": "confining_poly-3a679s",
+            "layout": {},
+            "paint": {
+                "fill-color": "hsl(60, 36%, 59%)",
+                "fill-outline-color": "hsla(0, 0%, 0%, 0)"
+            }
         }
-    }
-]
+    ]
+}

--- a/Symbology/web/Confinement/constriction_ratio.json
+++ b/Symbology/web/Confinement/constriction_ratio.json
@@ -1,18 +1,23 @@
-[
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    [ "hsl(200, 51%, 77%)", "Constriction Ratio" ]
+  ],
+  "layerStyles": [
     {
-        "id": "constriction-ratio-bxinm7",
-        "type": "line",
-        "source": "composite",
-        "source-layer": "constriction_ratio-bxinm7",
-        "layout": {},
-        "paint": {
-            "line-color": [
-                "step",
-                ["get", "Constriction_Ratio"],
-                "hsl(200, 51%, 77%)",
-                1,
-                "hsl(0, 100%, 50%)"
-            ]
-        }
+      "id": "constriction-ratio-bxinm7",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "constriction_ratio-bxinm7",
+      "layout": {},
+      "paint": {
+        "line-color": [
+          "step",
+          [ "get", "Constriction_Ratio" ],
+          "hsl(200, 51%, 77%)", 1,
+          "hsl(0, 100%, 50%)"
+        ]
+      }
     }
-]
+  ]
+}

--- a/Symbology/web/Confinement/error_polylines.json
+++ b/Symbology/web/Confinement/error_polylines.json
@@ -1,13 +1,19 @@
-[
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    [ "hsl(356, 76%, 49%)", "split points" ]
+  ],
+  "layerStyles": [
     {
-        "id": "error-polylines-546s2i",
-        "type": "line",
-        "source": "composite",
-        "source-layer": "error_polylines-546s2i",
-        "layout": {},
-        "paint": {
-            "line-dasharray": [1, 1],
-            "line-color": "hsl(356, 76%, 49%)"
-        }
+      "id": "error-polylines-546s2i",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "error_polylines-546s2i",
+      "layout": {},
+      "paint": {
+        "line-dasharray": [ 1, 1 ],
+        "line-color": "hsl(356, 76%, 49%)"
+      }
     }
-]
+  ]
+}

--- a/Symbology/web/Confinement/flowline_segments.json
+++ b/Symbology/web/Confinement/flowline_segments.json
@@ -1,10 +1,19 @@
-[
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    [ "hsl(1, 92%, 79%)", "flowline segments" ]
+  ],
+  "layerStyles": [
     {
-        "id": "flowline-segments-6juroz",
-        "type": "line",
-        "source": "composite",
-        "source-layer": "flowline_segments-6juroz",
-        "layout": {},
-        "paint": {"line-color": "hsl(1, 92%, 79%)", "line-width": 5}
+      "id": "flowline-segments-6juroz",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "flowline_segments-6juroz",
+      "layout": {},
+      "paint": {
+        "line-color": "hsl(1, 92%, 79%)",
+        "line-width": 5
+      }
     }
-]
+  ]
+}

--- a/Symbology/web/Confinement/flowlines.json
+++ b/Symbology/web/Confinement/flowlines.json
@@ -1,10 +1,18 @@
-[
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    [ "hsl(209, 88%, 48%)", "Flowlines"]
+  ],
+  "layerStyles": [
     {
-        "id": "flowlines-cwdhi5",
-        "type": "line",
-        "source": "composite",
-        "source-layer": "flowlines-cwdhi5",
-        "layout": {},
-        "paint": {"line-color": "hsl(209, 88%, 48%)"}
+      "id": "flowlines-cwdhi5",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "flowlines-cwdhi5",
+      "layout": {},
+      "paint": {
+        "line-color": "hsl(209, 88%, 48%)"
+      }
     }
-]
+  ]
+}

--- a/Symbology/web/Confinement/split_points.json
+++ b/Symbology/web/Confinement/split_points.json
@@ -1,10 +1,16 @@
-[
-    {
-        "id": "split-points-61tz45",
-        "type": "circle",
-        "source": "composite",
-        "source-layer": "split_points-61tz45",
-        "layout": {},
-        "paint": {}
-    }
-]
+{
+    "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+    "legend": [
+        ["rgba(0,0,0,255)", "split points"]
+    ],
+    "layerStyles":[
+        {
+            "id": "split-points-61tz45",
+            "type": "circle",
+            "source": "composite",
+            "source-layer": "split_points-61tz45",
+            "layout": {},
+            "paint": {}
+        }
+    ]
+  }

--- a/Symbology/web/Shared/nhdperrenial.json
+++ b/Symbology/web/Shared/nhdperrenial.json
@@ -1,18 +1,25 @@
-[
-  {
-      "id": "bratreachgeometry-bv59z4",
-      "type": "line",
-      "source": "composite",
-      "source-layer": "bratReachGeometry-bv59z4",
-      "layout": {},
-      "paint": {"line-color": "hsl(0, 100%, 44%)", "line-width": 10}
-  },
-  {
-      "id": "bratreachgeometry-bv59z4 copy",
-      "type": "symbol",
-      "source": "composite",
-      "source-layer": "bratReachGeometry-bv59z4",
-      "layout": {"text-field": ["get", "NHDPlusID"]},
-      "paint": {"text-color": "hsl(0, 0%, 100%)"}
-  }
-]
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(0, 100%, 44%)", "NHD Perrenial"]
+  ],
+  "layerStyles": [
+    {
+        "id": "bratreachgeometry-bv59z4",
+        "type": "line",
+        "source": "composite",
+        "source-layer": "bratReachGeometry-bv59z4",
+        "layout": {},
+        "paint": {"line-color": "hsl(0, 100%, 44%)", "line-width": 10}
+    },
+    {
+        "id": "bratreachgeometry-bv59z4 copy",
+        "type": "symbol",
+        "source": "composite",
+        "source-layer": "bratReachGeometry-bv59z4",
+        "layout": {"text-field": ["get", "NHDPlusID"]},
+        "paint": {"text-color": "hsl(0, 0%, 100%)"}
+    }
+  ]
+}
+

--- a/Symbology/web/vector.schema.json
+++ b/Symbology/web/vector.schema.json
@@ -12,7 +12,7 @@
         ]
       }
     },
-    "style": {
+    "layerStyles": {
       "type": "array",
       "items": [
         {
@@ -51,6 +51,6 @@
   },
   "required": [
     "legend",
-    "style"
+    "layerStyles"
   ]
 }

--- a/docs/Symbology/webRAVERasters.md
+++ b/docs/Symbology/webRAVERasters.md
@@ -1,0 +1,42 @@
+# WebRAVE Raster Symbology files
+
+After a discussion from @joewheaton we decided to simplify the work necessary to bring our QML files from QRave into the web so we can have symbolized rasters in WebRAVE. @lauren-herbine and @shelbysawyer this might apply to you at some point
+
+So how do we convert our QML raster symbolization to color ramps for the web?
+
+1. Use QGIS and QRAVE to load up the raster layer you want to symbolize for the web (assuming you already have a `.qml` for this layer of course)
+2. Open the symbology menu and click the little save icon. 
+
+<img width="575" alt="119533048-519e1700-bd3a-11eb-8dbe-759a2bcb3590" src="https://user-images.githubusercontent.com/1063391/122590840-f39de000-d016-11eb-920a-e43b25993285.png">
+
+That's it. Now just name it and put it in the right folder and push it to git.
+
+## File naming
+
+The only trick here is putting it in the right place with the right file name
+
+The filename must be `somename.txt` and the `somename` part should match what's in the symbology attribute in the business logic XML file (this is the same naming convention as the qml files. 
+
+So if my business logic looks like this:
+
+``` xml
+ <Node label="Detrended DEM (HAND - Height Above Nearest Drainge)" xpath="Raster[@id='HAND']" type="raster" symbology="hand" transparency="40" />
+```
+
+then my file name should be `hand.txt`
+
+## **_CASE MATTERS_**
+
+the `.txt` part should always be lowercase and the case of the filename should match EXACTLY what's in the business logic XML
+
+
+## Folder naming
+
+These files should live alongside the `.json` files for the webRAVE vectors
+
+``` bash
+# so if I want to put in a file shared across all projects then
+RiverscapesXML/Symbology/web/Shared/whatever.txt
+# otherwise, for project-specific symbologies
+RiverscapesXML/Symbology/web/ProjectTypeName/whatever.txt
+```

--- a/docs/Symbology/webRAVEVectors.md
+++ b/docs/Symbology/webRAVEVectors.md
@@ -1,0 +1,192 @@
+# WebRAVE Vector Symbology files
+
+The WebRave vector symbology format has evolved a bit. Here's an example.
+
+``` json
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/webRAVEVector.schema.json",
+  "legend": [
+    ["hsl(116, 57%, 39%)", "legend table layer 1"],
+    ["hsl(108, 87%, 59%)", "legend table layer 1"],
+    ["hsl(29, 100%, 50%)", "legend table layer 1"]
+  ],
+  "layerStyles": [
+      {
+          "id": "confinement-ratio-3oldrq",
+          "type": "line",
+          "source": "composite",
+          "source-layer": "confinement_ratio-3oldrq",
+          "layout": {},
+          "paint": {
+              "line-color": [
+                  "step",
+                  ["get", "Confinement_Ratio"],
+                  "hsl(116, 57%, 39%)", 0.1,
+                  "hsl(108, 87%, 59%)", 0.5,
+                  "hsl(29, 100%, 50%)", 0.85,
+                  "hsl(8, 100%, 50%)", 1.0000000000002822,
+                  "hsl(8, 100%, 50%)"
+              ]
+          }
+      }
+  ]
+}
+
+```
+
+Let's talk about the overall scructure
+
+``` JSON
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/webRAVEVector.schema.json",
+  "legend": [],
+  "layerStyles": []
+}
+```
+
+* `"$schema"` This points to the schema file. It's optional but if you use it then vscode will be able to tell you if there are problems with the file.
+* `"legend"`: This is the legend table information. You need to build this manually (see Below)
+* `"layerStyles"`: This is copied and pasted directly from mapBox style exports.
+
+
+## Creating a JSON file for use with webRAVE vector layers:
+
+Here are rough steps to get something symbolized for the web.
+
+1. In QGIS Export your layer as `GeoJSON`. Projection doesn't really matter but you might save yourself some trouble by using WGS84 so that you can throw baselayers under it in mapbox.
+   * You may need to remove the crs line that qgis seems to give it.: `"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },` Mapbox doesn't seem to support that
+   * If the file is too big for mapbox consider using a smaller HUC or not exporting fields you have no intention of symbolizing. You can also remove features in your layer to make it a more manageable size. We're just looking for a small, representative dataset that will let us work over a few zoom ranges.
+2. Log into [Mapbox Studio](https://studio.mapbox.com/). Click the `styles` tab and create a "new style" using the button. Choose the blank template. Give it a good name
+3. Go to layers and add a new layer. You should get an "Upload Data" option where you can drag and drop your geojson into a box. The notifications in the bottom right will tell you when it's done or if there are problems with the file upload or parsing.
+4. Now use the studio to symbolize with a few guidelines
+   * You need to duplicate the layer and change the type to get things like labels. So, for example, you might have one mapbox layer for symbols (labels), one for line styling and one for polygon fill styling. All layers consume from the same datasource.
+   * You can add copies of your datasource and convert them for things like labels, lines, polygons etc but you're not allowed to use anything else. Everything must derive from the geojson file you uploaded.
+   * You can add support layers like satellite maps underneath to help you see what your map will look like but you need to make sure these don't end up in the final product below. More about that later.
+5. When you're happy click the share button and export your style to a zip file.
+6. Unzip and pull out the JSON file inside.
+
+Here's what you're going to be looking at. Most of this file we can discard. The "layers" array is the only thing we care about.
+
+```json
+{
+    "version": 8,
+    "name": "WebRave Export demo",
+    "metadata": {
+        "mapbox:autocomposite": true,
+        "mapbox:type": "template",
+        "mapbox:sdk-support": {
+            "android": "9.3.0",
+            "ios": "5.10.0",
+            "js": "2.0.0"
+        },
+        "mapbox:groups": {},
+        "mapbox:uiParadigm": "layers"
+    },
+    "center": [-115.7276920252901, 46.04100776943545],
+    "zoom": 10.688254550618892,
+    "bearing": 0,
+    "pitch": 0,
+    "sources": {
+        "mapbox://mapbox.satellite": {
+            "url": "mapbox://mapbox.satellite",
+            "type": "raster",
+            "tileSize": 256
+        },
+        "composite": {
+            "url": "mapbox://northarrowresearch.5pojlt0g",
+            "type": "vector"
+        }
+    },
+    "sprite": "mapbox://sprites/northarrowresearch/ckox2hmjq0yn517p5re1fbtbb/ck2u8j60r58fu0sgyxrigm3cu",
+    "glyphs": "mapbox://fonts/northarrowresearch/{fontstack}/{range}.pbf",
+    "layers": [
+        {
+            "id": "confinement-ratio-3oldrq",
+            "type": "line",
+            "source": "composite",
+            "source-layer": "confinement_ratio-3oldrq",
+            "layout": {},
+            "paint": {
+                "line-color": [
+                    "step",
+                    ["get", "Confinement_Ratio"],
+                    "hsl(116, 57%, 39%)", 0.1,
+                    "hsl(108, 87%, 59%)", 0.5,
+                    "hsl(29, 100%, 50%)", 0.85,
+                    "hsl(8, 100%, 50%)", 1.0000000000002822,
+                    "hsl(8, 100%, 50%)"
+                ]
+            }
+        }
+    ],
+    "created": "2021-05-20T15:47:03.419Z",
+    "modified": "2021-05-20T15:54:44.257Z",
+    "id": "ckox2hmjq0yn517p5re1fbtbb",
+    "owner": "northarrowresearch",
+    "visibility": "private",
+    "draft": false
+}
+```
+
+
+7. Copy `layers` array and paste it into a new file under the "layerStyles" field
+
+In this case my new JSON file looks something like this:
+
+```json
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/webRAVEVector.schema.json",
+  "legend": [],
+  "layerStyles": [
+      {
+          "id": "confinement-ratio-3oldrq",
+          "type": "line",
+          "source": "composite",
+          "source-layer": "confinement_ratio-3oldrq",
+          "layout": {},
+          "paint": {
+              "line-color": [
+                  "step",
+                  ["get", "Confinement_Ratio"],
+                  "hsl(116, 57%, 39%)", 0.1,
+                  "hsl(108, 87%, 59%)", 0.5,
+                  "hsl(29, 100%, 50%)", 0.85,
+                  "hsl(8, 100%, 50%)", 1.0000000000002822,
+                  "hsl(8, 100%, 50%)"
+              ]
+          }
+      }
+  ]
+}
+```
+
+
+## File naming
+
+The only trick here is putting it in the right place with the right file name
+
+The filename must be `somename.json` and the `somename` part should match what's in the symbology attribute in the business logic XML file (this is the same naming convention as the qml files. 
+
+So if my business logic looks like this:
+
+``` xml
+<Node xpathlabel="Name" xpath="Outputs/Geopackage/Layers/Vector[@id='CONFINEMENT_RATIO']" type="line" id="confinement_ratio" symbology="confinement_ratio" />
+```
+
+then my file name should be `confinement_ratio.json`
+
+## **_CASE MATTERS_**
+
+the `.json` part should always be lowercase and the case of the filename should match EXACTLY what's in the business logic XML
+
+
+## Folder naming
+
+These files should live alongside the `.txt` files for the webRAVE rasters
+
+``` bash
+# so if I want to put in a file shared across all projects then
+RiverscapesXML/Symbology/web/Shared/whatever.json
+# otherwise, for project-specific symbologies
+RiverscapesXML/Symbology/web/ProjectTypeName/whatever.json
+```

--- a/docs/Symbology/webRAVEVectors.md
+++ b/docs/Symbology/webRAVEVectors.md
@@ -1,6 +1,6 @@
 # WebRAVE Vector Symbology files
 
-The WebRave vector symbology format has evolved a bit. Here's an example.
+The WebRave vector symbology format has evolved a bit. Here's an example of what we need now:
 
 ``` json
 {
@@ -31,10 +31,9 @@ The WebRave vector symbology format has evolved a bit. Here's an example.
       }
   ]
 }
-
 ```
 
-Let's talk about the overall scructure
+Let's summarize this overall scructure. There are 3 parts to this file:
 
 ``` JSON
 {
@@ -160,6 +159,28 @@ In this case my new JSON file looks something like this:
 }
 ```
 
+## Building the Legend Table Object
+
+``` json
+{
+  "legend": [
+    ["hsl(116, 57%, 39%)", "legend table layer 1"],
+    ["hsl(108, 87%, 59%)", "legend table layer 1"],
+    ["hsl(29, 100%, 50%)", "legend table layer 1"]
+  ]
+```
+
+The structure is pretty simple. It's a double array and the inner array is made up of two string values: A color string and a label string.
+
+The color string is any CSS-valid color value string ([more about what's allowed in css here](https://www.w3schools.com/cssref/css_colors_legal.asp)). You can use:
+
+* Hexadecimal colors: `#FF0000`
+* Hexadecimal colors with transparency: `#FF000055`
+* RGB colors: `rgb(255,0,0)`
+* RGBA colors: `rgba(255,0,0, 100)`
+* HSL colors: `hsl(116, 57%, 39%)`
+* HSLA colors: `hsla(116, 57%, 39%, 0.2)`
+* Predefined/Cross-browser color names: `red`
 
 ## File naming
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,6 +4,7 @@ certifi==2019.9.11
 chardet==3.0.4
 idna==2.8
 isort==4.3.21
+jsonschema==3.2.0
 lazy-object-proxy==1.4.3
 lxml==4.6.3
 mccabe==0.6.1

--- a/python/test.py
+++ b/python/test.py
@@ -3,7 +3,7 @@ import json
 # import sys
 # import csv
 import os
-from validate import get_xml, collect_files, get_xsd, validate_web_vector_json, validate_xml
+from validate import get_xml, collect_files, get_xsd, validate_web_vector_json, validate_xml, validate_qramp
 
 # We do this mapping because we want the current version's XML tested against the corrent
 # version's XSD. 
@@ -65,23 +65,22 @@ class TestLambdaFunc(unittest.TestCase):
 
         self.assertEqual(len(errors), 0, msg='Errors were found: \n{}'.format(self.err_helper(errors)))
 
-    # TODO: COLOR RAMPS ARE MORE COMPLICATED THAN JUST A CSV
-    # def test_validateRamp(self):
-    #     """CSV Ramps follow a very particular type
-    #     """        
-    #     errors = []
-    #     csv_paths = collect_files('./Symbology/web/**/*.txt')
-    #     for csv_path in csv_paths:
-    #         try:
-    #             with open(csv_path, 'r') as data:
-    #                 csv_lines = [l for l in csv.reader(data)]
-    #             result, errs = validate_ramp(csv_lines)
-    #             if not result:
-    #                 errors.append([csv_path, str(errs)])
-    #         except Exception as e:
-    #             errors.append([csv_path, 'Error parsing CSV: {}'.format(str(e))])
+    def test_validateRamp(self):
+        """QGIS Color Ramps follow a very particular type
+        """        
+        errors = []
+        ramp_paths = collect_files('./Symbology/web/**/*.txt')
+        for ramp_path in ramp_paths:
+            try:
+                with open(ramp_path, 'r') as data:
+                    ramp_file = data.read()
+                result, errs = validate_qramp(ramp_file)
+                if not result:
+                    errors.append([ramp_path, str(errs)])
+            except Exception as e:
+                errors.append([ramp_path, 'Error parsing QGIS Color Ramp: {}'.format(str(e))])
 
-    #     self.assertEqual(len(errors), 0, msg='Errors were found: \n{}'.format(self.err_helper(errors)))
+        self.assertEqual(len(errors), 0, msg='Errors were found: \n{}'.format(self.err_helper(errors)))
 
     def test_allProjectxmls(self):
         """Project XMLs need to be handled differently because each one has a different XSD file

--- a/python/test.py
+++ b/python/test.py
@@ -49,12 +49,14 @@ class TestLambdaFunc(unittest.TestCase):
         """
         errors = []
         json_paths = collect_files('./Symbology/web/**/*.json')
+        with open('./Symbology/web/vector.schema.json') as f:
+            schema = json.load(f)
         print("\nTesting Web Symbologies:\n========================")
         for json_path in json_paths:
             try:
                 with open(json_path, 'r') as f:
                     json_file = json.load(f)
-                result, errs = validate_web_vector_json(json_file)
+                result, errs = validate_web_vector_json(json_file, schema)
                 if not result:
                     errors.append([json_path, str(errs)])
             except Exception as e:

--- a/python/validate.py
+++ b/python/validate.py
@@ -88,13 +88,20 @@ def validate_qramp(qramp: str):
     if len(lines) < 3:
         errors.append('Ramp file was missing the minimum number of lines (3)')
         return False, errors
-    if lines[0].rstrip != "# QGIS Generated Color Map Export File":
-        errors.append('Missing the header line: "# QGIS Generated Color Map Export File". This is probabyl not a QGIS exported color ramp')
-    if "INTERPOLATION:" not in lines[1]: 
-        errors.append('Missing the intepolation type on line 2: "INTERPOLATED:[DISCRETE|INTERPOLATED|EXACT]". This is probabyl not a QGIS exported color ramp')
-    
-    pat = "^(.+?),(.+?),(.+?),(.+?),(.+?),(.+)$"
+
     result = True
+
+    if lines[0].rstrip() != "# QGIS Generated Color Map Export File":
+        errors.append('Missing the header line: "# QGIS Generated Color Map Export File". This is probabyl not a QGIS exported color ramp')
+        result = False
+    if "INTERPOLATION:" not in lines[1]:
+        errors.append('Missing the intepolation type on line 2: "INTERPOLATED:[DISCRETE|INTERPOLATED|EXACT]". This is probabyl not a QGIS exported color ramp')
+        result = False
+    if lines[1].split(':')[1] not in ['DISCRETE', 'EXACT', 'INTERPOLATED']:
+        errors.append("Interpolation value must be one of: 'DISCRETE', 'EXACT', 'INTERPOLATED'. Got: {}".format(lines[1]))
+        result = False
+
+    pat = "^(.+?),(.+?),(.+?),(.+?),(.+?),(.+)$"
     for cline in lines[2:]:
         # Blank lines are allowed at the end of the file
         # TODO: right now we're just ignoring blank lines anywhere


### PR DESCRIPTION
This is a followup to the symbology spec work and the discussions this week about our webRAVE symbologies

This pull request includes the new json schema, updated color ramps for rasters, updated json files for vectors.

I will be posting documentation and discussions soon for all this stuff. 