### PR TITLE
HAND QRAVE Updates

### DIFF
--- a/RaveBusinessLogic/HAND.xml
+++ b/RaveBusinessLogic/HAND.xml
@@ -7,29 +7,58 @@
         <Children collapsed="false">
             <Node label="Outputs" xpath="Outputs">
                 <Children collapsed="true">
-                    <Node label="Height Above Nearest Drainage" xpath="Raster[@id='HAND_RASTER']" type="raster" symbology="hand" transparency="40" id="hand" />
-                    <Node xpathlabel="Name" xpath="HTMLFile[@id='REPORT']" type="report" />
+                    <Node label="Height Above Nearest Drainage (HAND - i.e. relative elvation model)" xpath="Raster[@id='HAND_RASTER']" type="raster" symbology="hand" transparency="40" id="hand" />
+                    <Node label="HAND Report" xpath="HTMLFile[@id='REPORT']" type="file" />
                 </Children>
             </Node>
             <Node label="Inputs">
                 <Children collapsed="true">
-                    <Node xpathlabel="Name" xpath="Inputs/Geopackage/Layers/Vector[@id='HAND_NETWORK']" type="line" symbology="" />
-                    <Node xpathlabel="Name" xpath="Inputs/Geopackage/Layers/Vector[@id='DEM_MASK_POLY']" type="polygon" symbology="" />
-                    <Node label="Drainage Network" xpath="Inputs/Geopackage/Layers/Vector[@id='FLOWLINES']" type="line" symbology="flow_lines" />
-                    <Node label="Waterbody Polygon" xpath="Inputs/Geopackage/Layers/Vector[@id='FLOW_AREA']" type="polygon" symbology="nhdarea" />
-                    <Node xpathlabel="Name" xpath="Inputs/Raster[@id='DEM']" type="raster" symbology="" id="dem" transparency="40" />
-                    <Node xpathlabel="Name" xpath="Inputs/Raster[@id='HILLSHADE']" type="raster" symbology="" id="hillshade" />
+                    <Node label ="Drainage (i.e. active channel network or area)">
+                        <Children collapsed="true">
+                            <Node label="Channel Network (polyline)" xpath="Inputs/Geopackage/Layers/Vector[@id='FLOWLINES']" type="line" symbology="nhdperrenial" id="nhdperrenial"/>
+                            <Node label="Channel Area (polygon)" xpath="Inputs/Geopackage/Layers/Vector[@id='FLOW_AREA']" type="polygon" symbology="drainagecells" />
+                        </Children>
+                    </Node>
+                    <Node label ="Topography">
+                        <Children collapsed="true">
+                            <Node label="DEM Inpuut (digital elevation model)" xpath="Inputs/Raster[@id='DEM']" type="raster" symbology="dem" id="dem" transparency="40" />
+                            <Node label="Hillsahde" xpath="Inputs/Raster[@id='HILLSHADE']" type="raster" symbology="" id="hillshade" />
+                        </Children>
+                    </Node>
+                    <Node label ="Masked Analysis Extent (optional)" xpath="Inputs/Geopackage/Layers/Vector[@id='DEM_MASK_POLY']" type="polygon" symbology=""/>
                 </Children>
             </Node>
-            <Repeater label="Intermediates" xpath="Intermediates/Raster">
-                <Node xpathlabel="Name" type="raster" symbology="" />
-            </Repeater>
+            <Node label="Intermediates">
+                <Children collapsed="true">
+                    <Node label="Rasterized Drainage Cells (converted input)" xpath="Intermediates/Raster[@id='RASTERIZED_FLOWLINES']" type="raster" symbology="channelraster" transparency="40"/>
+                    <Node label="Masked DEM (optional)" xpath="Intermediates/Raster[@id='DEM_MASKED']" type="raster" symbology="dem" transparency="40" />
+                    <Node label="TauDEM Derivatives">
+                        <Children>
+                            <Node label="d∞ Flow Direction (Bearing)" xpath="Intermediates/Raster[@id='DINFFLOWDIR_ANG']" type="raster" symbology="" transparency="40"/>
+                            <Node label="d∞ Slope Angle (Degrees)" xpath="Intermediates/Raster[@id='DINFFLOWDIR_SLP']" type="raster" symbology="" transparency="40"/>
+                            <Node label="Pitfilled DEM" xpath="Intermediates/Raster[@id='PITFILL']" type="raster" symbology="dem" transparency="40"/>
+                        </Children>
+                    </Node>
+                    <Node label="Analysis Polygons">
+                        <Children collapsed="true">
+                            <Node label="Buffered Flowlines" xpath="Intermediates/Geopackage/Layers/Vector[@id='BUFFERED_FLOWLINES']" type="polygon" symbology="nhdarea" transparency="80"/>
+                            <Node label="Drainage Polygons" xpath="Intermediates/Geopackage/Layers/Vector[@id='DRAINAGE_POLYGONS']" type="polygon" symbology="nhdarea" transparency="80"/>
+                        </Children>
+                    </Node> 
+                </Children>
+            </Node>
         </Children>
     </Node>
     <Views default="DEFAULT">
-        <View name="HAND Default View" id="DEFAULT">
+        <View name="HAND Output" id="DEFAULT">
             <Layers>
                 <Layer id="hand" />
+                <Layer id="hillshade" />
+            </Layers>
+        </View>
+        <View name="HAND Input" id="input">
+            <Layers>
+                <Layer id="drainage" />
                 <Layer id="dem" />
                 <Layer id="hillshade" />
             </Layers>

--- a/Symbology/qgis/Shared/channelraster.qml
+++ b/Symbology/qgis/Shared/channelraster.qml
@@ -33,7 +33,7 @@
         <stdDevFactor>2</stdDevFactor>
       </minMaxOrigin>
       <colorPalette>
-        <paletteEntry color="#004da8" value="1" alpha="255" label="0"/>
+        <paletteEntry color="#004da8" value="1" alpha="255" label="Channel"/>
       </colorPalette>
       <colorramp type="randomcolors" name="[source]">
         <Option/>

--- a/Symbology/qgis/Shared/channelraster.qml
+++ b/Symbology/qgis/Shared/channelraster.qml
@@ -1,0 +1,48 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.18.3-Zürich" minScale="1e+08" styleCategories="AllStyleCategories" maxScale="0" hasScaleBasedVisibilityFlag="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <temporal enabled="0" mode="0" fetchMode="0">
+    <fixedRange>
+      <start></start>
+      <end></end>
+    </fixedRange>
+  </temporal>
+  <customproperties>
+    <property value="false" key="WMSBackgroundLayer"/>
+    <property value="false" key="WMSPublishDataSourceUrl"/>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property value="Value" key="identify/format"/>
+  </customproperties>
+  <pipe>
+    <provider>
+      <resampling enabled="false" maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" zoomedInResamplingMethod="nearestNeighbour"/>
+    </provider>
+    <rasterrenderer alphaBand="-1" opacity="0.6" type="paletted" nodataColor="" band="1">
+      <rasterTransparency/>
+      <minMaxOrigin>
+        <limits>None</limits>
+        <extent>WholeRaster</extent>
+        <statAccuracy>Estimated</statAccuracy>
+        <cumulativeCutLower>0.02</cumulativeCutLower>
+        <cumulativeCutUpper>0.98</cumulativeCutUpper>
+        <stdDevFactor>2</stdDevFactor>
+      </minMaxOrigin>
+      <colorPalette>
+        <paletteEntry color="#004da8" value="1" alpha="255" label="0"/>
+      </colorPalette>
+      <colorramp type="randomcolors" name="[source]">
+        <Option/>
+      </colorramp>
+    </rasterrenderer>
+    <brightnesscontrast gamma="1" contrast="0" brightness="0"/>
+    <huesaturation grayscaleMode="0" colorizeStrength="100" saturation="0" colorizeOn="0" colorizeRed="255" colorizeGreen="128" colorizeBlue="128"/>
+    <rasterresampler maxOversampling="2"/>
+    <resamplingStage>resamplingFilter</resamplingStage>
+  </pipe>
+  <blendMode>0</blendMode>
+</qgis>

--- a/Symbology/qgis/Shared/hand.qml
+++ b/Symbology/qgis/Shared/hand.qml
@@ -1,9 +1,10 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" maxScale="0" minScale="1e+08" version="3.16.5-Hannover" hasScaleBasedVisibilityFlag="0">
+<qgis version="3.18.3-Zürich" minScale="1e+08" styleCategories="AllStyleCategories" maxScale="0" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
+    <Private>0</Private>
   </flags>
   <temporal enabled="0" mode="0" fetchMode="0">
     <fixedRange>
@@ -12,13 +13,16 @@
     </fixedRange>
   </temporal>
   <customproperties>
-    <property key="identify/format" value="Value"/>
+    <property value="false" key="WMSBackgroundLayer"/>
+    <property value="false" key="WMSPublishDataSourceUrl"/>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property value="Value" key="identify/format"/>
   </customproperties>
   <pipe>
     <provider>
-      <resampling enabled="false" zoomedInResamplingMethod="nearestNeighbour" maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour"/>
+      <resampling enabled="false" maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" zoomedInResamplingMethod="nearestNeighbour"/>
     </provider>
-    <rasterrenderer type="singlebandpseudocolor" classificationMin="0" band="1" classificationMax="931.0211792" alphaBand="-1" nodataColor="" opacity="0.7">
+    <rasterrenderer alphaBand="-1" opacity="0.6" classificationMin="0" classificationMax="361.6794739" type="singlebandpseudocolor" nodataColor="" band="1">
       <rasterTransparency/>
       <minMaxOrigin>
         <limits>MinMax</limits>
@@ -29,31 +33,53 @@
         <stdDevFactor>2</stdDevFactor>
       </minMaxOrigin>
       <rastershader>
-        <colorrampshader maximumValue="931.02117920000001" colorRampType="DISCRETE" classificationMode="2" clip="0" labelPrecision="1" minimumValue="0">
-          <colorramp name="[source]" type="gradient">
-            <prop v="215,25,28,255" k="color1"/>
-            <prop v="43,131,186,255" k="color2"/>
+        <colorrampshader clip="0" minimumValue="0" classificationMode="2" maximumValue="361.6794739" labelPrecision="0" colorRampType="DISCRETE">
+          <colorramp type="gradient" name="[source]">
+            <Option type="Map">
+              <Option value="0,77,168,255" type="QString" name="color1"/>
+              <Option value="252,252,252,255" type="QString" name="color2"/>
+              <Option value="0" type="QString" name="discrete"/>
+              <Option value="gradient" type="QString" name="rampType"/>
+              <Option value="0.00069122;38,115,0,255:0.00138244;121,172,96,255:0.00276488;127,189,93,255:0.00552976;147,219,94,255:0.00829464;195,252,91,255:0.0110595;214,255,132,255:0.0138244;237,255,176,255:0.0276488;255,248,199,255:0.069122;255,229,158,255:0.138244;242,171,0,255:0.276488;145,133,104,255:0.69122;156,156,156,255" type="QString" name="stops"/>
+            </Option>
+            <prop v="0,77,168,255" k="color1"/>
+            <prop v="252,252,252,255" k="color2"/>
             <prop v="0" k="discrete"/>
             <prop v="gradient" k="rampType"/>
-            <prop v="0.25;253,174,97,255:0.5;255,255,191,255:0.75;171,221,164,255" k="stops"/>
+            <prop v="0.00069122;38,115,0,255:0.00138244;121,172,96,255:0.00276488;127,189,93,255:0.00552976;147,219,94,255:0.00829464;195,252,91,255:0.0110595;214,255,132,255:0.0138244;237,255,176,255:0.0276488;255,248,199,255:0.069122;255,229,158,255:0.138244;242,171,0,255:0.276488;145,133,104,255:0.69122;156,156,156,255" k="stops"/>
           </colorramp>
-          <item color="#79ac60" alpha="255" label="&lt;= 0.5" value="0.5"/>
-          <item color="#7fbd5d" alpha="255" label="0.5 - 1.0" value="1"/>
-          <item color="#93db5e" alpha="255" label="1.0 - 2.0" value="2"/>
-          <item color="#c3fc5b" alpha="255" label="2.0 - 3.0" value="3"/>
-          <item color="#d6ff84" alpha="255" label="3.0 - 4.0" value="4"/>
-          <item color="#edffb0" alpha="255" label="4.0 - 5.0" value="5"/>
-          <item color="#fff8c7" alpha="255" label="5 - 10" value="10"/>
-          <item color="#ffe59e" alpha="255" label="10 - 25" value="25"/>
-          <item color="#f2ab00" alpha="255" label="25 - 50" value="50"/>
-          <item color="#918568" alpha="255" label="50 - 100" value="100"/>
-          <item color="#9c9c9c" alpha="255" label="100- 250" value="250"/>
-          <item color="#fcfcfc" alpha="255" label="> 250" value="inf"/>
+          <item color="#004da8" value="0" alpha="255" label="0 (Active Channel)"/>
+          <item color="#267300" value="0.25" alpha="255" label="0.00 - 0.25 m"/>
+          <item color="#79ac60" value="0.5" alpha="255" label="0.25 - 0.50 m"/>
+          <item color="#7fbd5d" value="1" alpha="255" label="0.50 - 1.00 m"/>
+          <item color="#93db5e" value="2" alpha="255" label="1 - 2 m"/>
+          <item color="#c3fc5b" value="3" alpha="255" label="2 - 3 m"/>
+          <item color="#d6ff84" value="4" alpha="255" label="3 - 4 m"/>
+          <item color="#edffb0" value="5" alpha="255" label="4 - 5 m"/>
+          <item color="#fff8c7" value="10" alpha="255" label="5 - 10 m"/>
+          <item color="#ffe59e" value="25" alpha="255" label="10 - 25 m"/>
+          <item color="#f2ab00" value="50" alpha="255" label="25 - 50 m"/>
+          <item color="#918568" value="100" alpha="255" label="50 - 100 m"/>
+          <item color="#9c9c9c" value="250" alpha="255" label="100- 250 m"/>
+          <item color="#fcfcfc" value="inf" alpha="255" label="> 250 m"/>
+          <rampLegendSettings minimumLabel="" prefix="" suffix="" maximumLabel="" orientation="2" useContinuousLegend="1" direction="0">
+            <numericFormat id="basic">
+              <Option type="Map">
+                <Option value="" type="QChar" name="decimal_separator"/>
+                <Option value="6" type="int" name="decimals"/>
+                <Option value="0" type="int" name="rounding_type"/>
+                <Option value="false" type="bool" name="show_plus"/>
+                <Option value="true" type="bool" name="show_thousand_separator"/>
+                <Option value="false" type="bool" name="show_trailing_zeros"/>
+                <Option value="" type="QChar" name="thousand_separator"/>
+              </Option>
+            </numericFormat>
+          </rampLegendSettings>
         </colorrampshader>
       </rastershader>
     </rasterrenderer>
-    <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-    <huesaturation colorizeStrength="100" grayscaleMode="0" colorizeGreen="128" colorizeBlue="128" colorizeRed="255" saturation="0" colorizeOn="0"/>
+    <brightnesscontrast gamma="1" contrast="0" brightness="0"/>
+    <huesaturation grayscaleMode="0" colorizeStrength="100" saturation="0" colorizeOn="0" colorizeRed="255" colorizeGreen="128" colorizeBlue="128"/>
     <rasterresampler maxOversampling="2"/>
     <resamplingStage>resamplingFilter</resamplingStage>
   </pipe>


### PR DESCRIPTION
Updates per #121 to business logic, `hand.qml` and added a new binary `channelraster.qml`. 

## New Business Logic Layout
![image](https://user-images.githubusercontent.com/9723905/123525908-651e0400-d691-11eb-8e12-59e86b3f63ae.png)
@nick4rivers feel free to suggest tweaks or changes in your review. This will change some more as HAND keeps evolving. @KellyMWhitehead and @philipbaileynar may also wish to review.

### Old Business Logic Layout
![image](https://user-images.githubusercontent.com/9723905/123525820-c4c7df80-d690-11eb-90cd-5c78d6e12680.png)
-------------
## Symbology
### New HAND
![image](https://user-images.githubusercontent.com/9723905/123526132-09ed1100-d693-11eb-8fda-09043833c9ae.png)

### New Channel
![image](https://user-images.githubusercontent.com/9723905/123526201-72d48900-d693-11eb-82d5-6f732a113838.png)

### New Defaults Output View
![image](https://user-images.githubusercontent.com/9723905/123525948-c645d780-d691-11eb-929a-a9a4a1748c44.png)

### New Input View
![image](https://user-images.githubusercontent.com/9723905/123525995-1a50bc00-d692-11eb-8585-97905eb9f149.png)
Problem right now is that input of channel network is actually `HANDNETWORK` from:
https://github.com/Riverscapes/RiverscapesXML/blob/b6f56ba98183b497992f8c31b630e43f4181b29f/RaveBusinessLogic/HAND.xml#L16
Whereas it will become `FLOWLINES` if user provides polyline input and `FLOWAREA` if user provides polygon channel/drainage input, and that is what is in my edits:
https://github.com/Riverscapes/RiverscapesXML/blob/75d93d5f5d0ddd43ff54cfffd94f362f03f55db9/RaveBusinessLogic/HAND.xml#L16-L21