### PR TITLE
Some VBET Quick-fixes to Symbology

### DIFF
--- a/RaveBusinessLogic/VBET.xml
+++ b/RaveBusinessLogic/VBET.xml
@@ -8,8 +8,8 @@
     <Children collapsed="false">
       <Node label="Outputs" xpath="Outputs">
         <Children>
-          <Node label="Likelihood of Valley Bottom" xpath="Raster[@id='VBET_EVIDENCE']" type="raster" symbology="vbetLikelihood" transparency="40" />
-          <Node label="Valley Bottom Extent (Hollow)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet_extent_hollow" />               
+          <Node label="Likelihood of being Valley Bottom" xpath="Raster[@id='VBET_EVIDENCE']" type="raster" symbology="vbetLikelihood" transparency="40" id="LVBET" />
+          <Node label="Valley Bottom Extent (Hollow)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet_extent_hollow" id="vbet_extent_hollow" />               
           <Node label="Valley Bottom Extent (Filled)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet_extent_filled" transparency="40" />              
           <Node label="Valley Bottom Geomorphic Units">
             <Children>

--- a/RaveBusinessLogic/VBET.xml
+++ b/RaveBusinessLogic/VBET.xml
@@ -42,7 +42,6 @@
               <Node label="Normalized Slope Evidence" xpath="Raster[@id='NORMALIZED_SLOPE']" type="raster" symbology="norm_slope" transparency="40" />
               <Node label="Normalized HAND Evidence" xpath="Raster[@id='NORMALIZED_HAND']" type="raster" symbology="norm_hand" transparency="40" />
               <Node label="Normalized TWI Evidence" xpath="Raster[@id='NORMALIZED_TWI']" type="raster" symbology="norm_twi" transparency="40" />
-              <Node label="Normalized Channel Evidence" xpath="" type="raster" symbology="norm_channel" transparency="40" />
               <Node label="Combined Topographic Evidence" xpath="Raster[@id='EVIDENCE_TOPO']" type="raster" symbology="norm_topo" transparency="40" />
             </Children>
           </Node>

--- a/RaveBusinessLogic/VBET.xml
+++ b/RaveBusinessLogic/VBET.xml
@@ -8,9 +8,9 @@
     <Children collapsed="false">
       <Node label="Outputs" xpath="Outputs">
         <Children>
-          <Node label="Likelihood of being Valley Bottom" xpath="Raster[@id='VBET_EVIDENCE']" type="raster" symbology="vbetLikelihood" transparency="40" id="LVBET" />
+          <Node label="Likelihood of being Valley Bottom" xpath="Raster[@id='VBET_EVIDENCE']" type="raster" symbology="vbetLikelihood" transparency="40" id="likevbet" />
           <Node label="Valley Bottom Extent (Hollow)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet_extent_hollow" id="vbet_extent_hollow" />               
-          <Node label="Valley Bottom Extent (Filled)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet_extent_filled" transparency="40" />              
+          <Node label="Valley Bottom Extent (Filled)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet_extent_filled" transparency="40" id="vbet_extent_filled" />              
           <Node label="Valley Bottom Geomorphic Units">
             <Children>
               <Node label="Estimated Active Channel" xpath="Geopackage/Layers/Vector[@id='vbet_channel_area']" type="polygon" symbology="vbet_channel_area" />                        
@@ -50,10 +50,10 @@
     </Children>
   </Node>
   <Views default="DEFAULT">
-    <View name="VBET Default View" id="DEFAULT">
+    <View name="VBET Output" id="DEFAULT">
       <Layers>
-        <Layer id="vbet_extent_follow" />
-        <Layer id="vbet_channel_area" />
+        <Layer id="likevbet" />
+        <Layer id="vbet_extent_hollow" />
         <Layer id="hillshade" />
       </Layers>
     </View>

--- a/RaveBusinessLogic/VBET.xml
+++ b/RaveBusinessLogic/VBET.xml
@@ -13,9 +13,9 @@
           <Node label="Valley Bottom Extent (Filled)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet68_filled" transparency="40" id="vbet_extent_filled" />              
           <Node label="Valley Bottom Geomorphic Units">
             <Children>
-              <Node label="Estimated Active Channel" xpath="Geopackage/Layers/Vector[@id='vbet_channel_area']" type="polygon" symbology="vbet_channel_area" />                        
-              <Node label="Estimated Active Floodplain" xpath="Geopackage/Layers/Vector[@id='vbet_active_floodplain']" type="polygon" symbology="active_floodplain" id="vbet70outline"/>
-              <Node label="Estimated Inactive Floodplain" xpath="Geopackage/Layers/Vector[@id='vbet_inactive_floodplain']" type="polygon" symbology="inactive_floodplain" id="vbet50outline"/>      
+              <Node label="Estimated Active Channel" xpath="Geopackage/Layers/Vector[@id='VBET_CHANNEL_AREA']" type="polygon" symbology="vbet_channel_area" />                        
+              <Node label="Estimated Active Floodplain" xpath="Geopackage/Layers/Vector[@id='ACTIVE_FLOODPLAIN']" type="polygon" symbology="active_floodplain" id="vbet70outline"/>
+              <Node label="Estimated Inactive Floodplain" xpath="Geopackage/Layers/Vector[@id='INACTIVE_FLOODPLAIN']" type="polygon" symbology="inactive_floodplain" id="vbet50outline"/>      
             </Children>
           </Node>
         </Children>

--- a/RaveBusinessLogic/VBET.xml
+++ b/RaveBusinessLogic/VBET.xml
@@ -13,9 +13,9 @@
           <Node label="Valley Bottom Extent (Filled)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet68_filled" transparency="40" id="vbet_extent_filled" />              
           <Node label="Valley Bottom Geomorphic Units">
             <Children>
-              <Node label="Estimated Active Channel" xpath="Geopackage/Layers/Vector[@id='VBET_CHANNEL_AREA']" type="polygon" symbology="vbet_channel_area" />                        
-              <Node label="Estimated Active Floodplain" xpath="Geopackage/Layers/Vector[@id='ACTIVE_FLOODPLAIN']" type="polygon" symbology="active_floodplain" id="vbet70outline"/>
-              <Node label="Estimated Inactive Floodplain" xpath="Geopackage/Layers/Vector[@id='INACTIVE_FLOODPLAIN']" type="polygon" symbology="inactive_floodplain" id="vbet50outline"/>      
+              <Node label="Estimated Active Channel" xpath="Geopackage/Layers/Vector[@id='VBET_CHANNEL_AREA']" type="polygon" symbology="vbet_channel_area" id="vbet_channel_area" />                        
+              <Node label="Estimated Active Floodplain" xpath="Geopackage/Layers/Vector[@id='ACTIVE_FLOODPLAIN']" type="polygon" symbology="vbet_active_floodplain" id="vbet_active_floodplain"/>
+              <Node label="Estimated Inactive Floodplain" xpath="Geopackage/Layers/Vector[@id='INACTIVE_FLOODPLAIN']" type="polygon" symbology="vbet_inactive_floodplain" id="vbet_inactive_floodplain"/>      
             </Children>
           </Node>
         </Children>
@@ -50,11 +50,18 @@
     </Children>
   </Node>
   <Views default="DEFAULT">
-    <View name="VBET Output" id="DEFAULT">
+    <View name="Primary Output" id="DEFAULT">
       <Layers>
         <Layer id="likevbet" />
         <Layer id="vbet_extent_hollow" />
         <Layer id="hillshade" />
+      </Layers>
+    </View>
+    <View name="Estimated Valley Bottom Geomorphic Units" id="GU">
+      <Layers>
+        <Layer id="vbet_channel_area" />
+        <Layer id="vbet_active_floodplain" />
+        <Layer id="vbet_inactive_floodplain" />
       </Layers>
     </View>
     <View name="VBET Inputs" id="Inputs">

--- a/RaveBusinessLogic/VBET.xml
+++ b/RaveBusinessLogic/VBET.xml
@@ -9,8 +9,8 @@
       <Node label="Outputs" xpath="Outputs">
         <Children>
           <Node label="Likelihood of being Valley Bottom" xpath="Raster[@id='VBET_EVIDENCE']" type="raster" symbology="vbetLikelihood" transparency="40" id="likevbet" />
-          <Node label="Valley Bottom Extent (Hollow)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet_extent_hollow" id="vbet_extent_hollow" />               
-          <Node label="Valley Bottom Extent (Filled)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet_extent_filled" transparency="40" id="vbet_extent_filled" />              
+          <Node label="Valley Bottom Extent (Hollow)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet68_hollow" id="vbet_extent_hollow" />               
+          <Node label="Valley Bottom Extent (Filled)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet68_filled" transparency="40" id="vbet_extent_filled" />              
           <Node label="Valley Bottom Geomorphic Units">
             <Children>
               <Node label="Estimated Active Channel" xpath="Geopackage/Layers/Vector[@id='vbet_channel_area']" type="polygon" symbology="vbet_channel_area" />                        

--- a/Symbology/qgis/VBET/vbet68_filled.qml
+++ b/Symbology/qgis/VBET/vbet68_filled.qml
@@ -1,0 +1,55 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.18.2-Zürich" styleCategories="Symbology|Legend">
+  <renderer-v2 forceraster="0" symbollevels="0" enableorderby="0" type="singleSymbol">
+    <symbols>
+      <symbol name="0" clip_to_extent="1" force_rhr="0" type="fill" alpha="0.6">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer pass="0" enabled="1" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="77,175,74,255" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="56,128,54,0" type="QString"/>
+            <Option name="outline_style" value="no" type="QString"/>
+            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="77,175,74,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="56,128,54,0" k="outline_color"/>
+          <prop v="no" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <legend type="default-vector"/>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/Symbology/qgis/VBET/vbet68_hollow.qml
+++ b/Symbology/qgis/VBET/vbet68_hollow.qml
@@ -1,0 +1,128 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.18.2-Zürich" styleCategories="Symbology|Legend">
+  <renderer-v2 forceraster="0" symbollevels="0" enableorderby="0" type="singleSymbol">
+    <symbols>
+      <symbol name="0" clip_to_extent="1" force_rhr="0" type="fill" alpha="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer pass="0" enabled="1" class="SimpleLine" locked="0">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="91,91,91,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="Pixel" type="QString"/>
+            <Option name="offset" value="-0.2" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <prop v="0" k="align_dash_pattern"/>
+          <prop v="square" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="dash_pattern_offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+          <prop v="MM" k="dash_pattern_offset_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="91,91,91,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="0.26" k="line_width"/>
+          <prop v="Pixel" k="line_width_unit"/>
+          <prop v="-0.2" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="tweak_dash_pattern_on_corners"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer pass="0" enabled="1" class="SimpleLine" locked="0">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="255,255,255,255" type="QString"/>
+            <Option name="line_style" value="dash" type="QString"/>
+            <Option name="line_width" value="1" type="QString"/>
+            <Option name="line_width_unit" value="Pixel" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <prop v="0" k="align_dash_pattern"/>
+          <prop v="square" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="dash_pattern_offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+          <prop v="MM" k="dash_pattern_offset_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="255,255,255,255" k="line_color"/>
+          <prop v="dash" k="line_style"/>
+          <prop v="1" k="line_width"/>
+          <prop v="Pixel" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="tweak_dash_pattern_on_corners"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <legend type="default-vector"/>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/Symbology/qgis/VBET/vbet_active_floodplain.qml
+++ b/Symbology/qgis/VBET/vbet_active_floodplain.qml
@@ -1,0 +1,55 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.18.2-Zürich" styleCategories="Symbology|Legend">
+  <renderer-v2 forceraster="0" symbollevels="0" enableorderby="0" type="singleSymbol">
+    <symbols>
+      <symbol name="0" clip_to_extent="1" force_rhr="0" type="fill" alpha="0.6">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer pass="0" enabled="1" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="77,175,74,255" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="56,128,54,255" type="QString"/>
+            <Option name="outline_style" value="no" type="QString"/>
+            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="77,175,74,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="56,128,54,255" k="outline_color"/>
+          <prop v="no" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <legend type="default-vector"/>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/Symbology/qgis/VBET/vbet_channel_area.qml
+++ b/Symbology/qgis/VBET/vbet_channel_area.qml
@@ -1,0 +1,55 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.18.2-Zürich" styleCategories="Symbology|Legend">
+  <renderer-v2 forceraster="0" symbollevels="0" enableorderby="0" type="singleSymbol">
+    <symbols>
+      <symbol name="0" clip_to_extent="1" force_rhr="0" type="fill" alpha="0.7">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer pass="0" enabled="1" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="55,126,184,255" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="25,52,72,255" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="55,126,184,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="25,52,72,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <legend type="default-vector"/>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/Symbology/qgis/VBET/vbet_inactive_floodplain.qml
+++ b/Symbology/qgis/VBET/vbet_inactive_floodplain.qml
@@ -1,0 +1,205 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.18.2-Zürich" styleCategories="Symbology|Legend">
+  <renderer-v2 forceraster="0" symbollevels="0" enableorderby="0" type="singleSymbol">
+    <symbols>
+      <symbol name="0" clip_to_extent="1" force_rhr="0" type="fill" alpha="0.6">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer pass="0" enabled="1" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="228,224,28,255" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="128,14,16,255" type="QString"/>
+            <Option name="outline_style" value="no" type="QString"/>
+            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="228,224,28,255" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="128,14,16,255" k="outline_color"/>
+          <prop v="no" k="outline_style"/>
+          <prop v="0.26" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <effect enabled="0" type="effectStack">
+            <effect type="dropShadow">
+              <Option type="Map">
+                <Option name="blend_mode" value="13" type="QString"/>
+                <Option name="blur_level" value="2.645" type="QString"/>
+                <Option name="blur_unit" value="MM" type="QString"/>
+                <Option name="blur_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color" value="0,0,0,255" type="QString"/>
+                <Option name="draw_mode" value="2" type="QString"/>
+                <Option name="enabled" value="0" type="QString"/>
+                <Option name="offset_angle" value="135" type="QString"/>
+                <Option name="offset_distance" value="2" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="offset_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="opacity" value="1" type="QString"/>
+              </Option>
+              <prop v="13" k="blend_mode"/>
+              <prop v="2.645" k="blur_level"/>
+              <prop v="MM" k="blur_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+              <prop v="0,0,0,255" k="color"/>
+              <prop v="2" k="draw_mode"/>
+              <prop v="0" k="enabled"/>
+              <prop v="135" k="offset_angle"/>
+              <prop v="2" k="offset_distance"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+              <prop v="1" k="opacity"/>
+            </effect>
+            <effect type="outerGlow">
+              <Option type="Map">
+                <Option name="blend_mode" value="0" type="QString"/>
+                <Option name="blur_level" value="0.7935" type="QString"/>
+                <Option name="blur_unit" value="MM" type="QString"/>
+                <Option name="blur_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color1" value="0,0,255,255" type="QString"/>
+                <Option name="color2" value="0,255,0,255" type="QString"/>
+                <Option name="color_type" value="0" type="QString"/>
+                <Option name="discrete" value="0" type="QString"/>
+                <Option name="draw_mode" value="2" type="QString"/>
+                <Option name="enabled" value="0" type="QString"/>
+                <Option name="opacity" value="0.5" type="QString"/>
+                <Option name="rampType" value="gradient" type="QString"/>
+                <Option name="single_color" value="255,255,255,255" type="QString"/>
+                <Option name="spread" value="2" type="QString"/>
+                <Option name="spread_unit" value="MM" type="QString"/>
+                <Option name="spread_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              </Option>
+              <prop v="0" k="blend_mode"/>
+              <prop v="0.7935" k="blur_level"/>
+              <prop v="MM" k="blur_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+              <prop v="0,0,255,255" k="color1"/>
+              <prop v="0,255,0,255" k="color2"/>
+              <prop v="0" k="color_type"/>
+              <prop v="0" k="discrete"/>
+              <prop v="2" k="draw_mode"/>
+              <prop v="0" k="enabled"/>
+              <prop v="0.5" k="opacity"/>
+              <prop v="gradient" k="rampType"/>
+              <prop v="255,255,255,255" k="single_color"/>
+              <prop v="2" k="spread"/>
+              <prop v="MM" k="spread_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+            </effect>
+            <effect type="blur">
+              <Option type="Map">
+                <Option name="blend_mode" value="0" type="QString"/>
+                <Option name="blur_level" value="2.645" type="QString"/>
+                <Option name="blur_method" value="0" type="QString"/>
+                <Option name="blur_unit" value="MM" type="QString"/>
+                <Option name="blur_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="draw_mode" value="2" type="QString"/>
+                <Option name="enabled" value="1" type="QString"/>
+                <Option name="opacity" value="1" type="QString"/>
+              </Option>
+              <prop v="0" k="blend_mode"/>
+              <prop v="2.645" k="blur_level"/>
+              <prop v="0" k="blur_method"/>
+              <prop v="MM" k="blur_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+              <prop v="2" k="draw_mode"/>
+              <prop v="1" k="enabled"/>
+              <prop v="1" k="opacity"/>
+            </effect>
+            <effect type="innerShadow">
+              <Option type="Map">
+                <Option name="blend_mode" value="13" type="QString"/>
+                <Option name="blur_level" value="2.645" type="QString"/>
+                <Option name="blur_unit" value="MM" type="QString"/>
+                <Option name="blur_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color" value="0,0,0,255" type="QString"/>
+                <Option name="draw_mode" value="2" type="QString"/>
+                <Option name="enabled" value="0" type="QString"/>
+                <Option name="offset_angle" value="135" type="QString"/>
+                <Option name="offset_distance" value="2" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="offset_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="opacity" value="1" type="QString"/>
+              </Option>
+              <prop v="13" k="blend_mode"/>
+              <prop v="2.645" k="blur_level"/>
+              <prop v="MM" k="blur_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+              <prop v="0,0,0,255" k="color"/>
+              <prop v="2" k="draw_mode"/>
+              <prop v="0" k="enabled"/>
+              <prop v="135" k="offset_angle"/>
+              <prop v="2" k="offset_distance"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+              <prop v="1" k="opacity"/>
+            </effect>
+            <effect type="innerGlow">
+              <Option type="Map">
+                <Option name="blend_mode" value="0" type="QString"/>
+                <Option name="blur_level" value="0.7935" type="QString"/>
+                <Option name="blur_unit" value="MM" type="QString"/>
+                <Option name="blur_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color1" value="0,0,255,255" type="QString"/>
+                <Option name="color2" value="0,255,0,255" type="QString"/>
+                <Option name="color_type" value="0" type="QString"/>
+                <Option name="discrete" value="0" type="QString"/>
+                <Option name="draw_mode" value="2" type="QString"/>
+                <Option name="enabled" value="0" type="QString"/>
+                <Option name="opacity" value="0.5" type="QString"/>
+                <Option name="rampType" value="gradient" type="QString"/>
+                <Option name="single_color" value="255,255,255,255" type="QString"/>
+                <Option name="spread" value="2" type="QString"/>
+                <Option name="spread_unit" value="MM" type="QString"/>
+                <Option name="spread_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              </Option>
+              <prop v="0" k="blend_mode"/>
+              <prop v="0.7935" k="blur_level"/>
+              <prop v="MM" k="blur_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+              <prop v="0,0,255,255" k="color1"/>
+              <prop v="0,255,0,255" k="color2"/>
+              <prop v="0" k="color_type"/>
+              <prop v="0" k="discrete"/>
+              <prop v="2" k="draw_mode"/>
+              <prop v="0" k="enabled"/>
+              <prop v="0.5" k="opacity"/>
+              <prop v="gradient" k="rampType"/>
+              <prop v="255,255,255,255" k="single_color"/>
+              <prop v="2" k="spread"/>
+              <prop v="MM" k="spread_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+            </effect>
+          </effect>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <legend type="default-vector"/>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>


### PR DESCRIPTION
This is just business logic changes to VBET to get it to work for changes. Note, @shelbysawyer I cannot find anywhere youre Normalized Evidence *.qml (they are not on any of the branches). I have seen them, so I know you made them. So these edits just fix business logic and add some new geomorphic unit qmls. 