### PR TITLE
QRAVE Normalized Evidence Raster Symbology

### DIFF
--- a/RaveBusinessLogic/VBET.xml
+++ b/RaveBusinessLogic/VBET.xml
@@ -42,7 +42,7 @@
               <Node label="Normalized Slope Evidence" xpath="Raster[@id='NORMALIZED_SLOPE']" type="raster" symbology="norm_slope" transparency="40" />
               <Node label="Normalized HAND Evidence" xpath="Raster[@id='NORMALIZED_HAND']" type="raster" symbology="norm_hand" transparency="40" />
               <Node label="Normalized TWI Evidence" xpath="Raster[@id='NORMALIZED_TWI']" type="raster" symbology="norm_twi" transparency="40" />
-              <Node label="Combined Topographic Evidence" xpath="Raster[@id='EVIDENCE_TOPO']" type="raster" symbology="norm_topo" transparency="40" />
+              <Node label="Combined Topographic Evidence" xpath="Raster[@id='EVIDENCE_TOPO']" type="raster" symbology="norm_topo" transparency="40" id="norm_topo" />
             </Children>
           </Node>
         </Children>
@@ -64,11 +64,17 @@
         <Layer id="vbet_inactive_floodplain" />
       </Layers>
     </View>
+    <View name="Normalized Evidence" id="Norm">
+      <Layers>
+        <Layer id="norm_topo" />
+        <Layer id="hillshade" />
+      </Layers>
+    </View>
     <View name="VBET Inputs" id="Inputs">
       <Layers>
+        <Layer id="channel_area_polygons" />
         <Layer id="dem" />
         <Layer id="hillshade" />
-        <Layer id="channel_area_polygons" />
       </Layers>
     </View>
   </Views>

--- a/Symbology/qgis/VBET/norm_hand.qml
+++ b/Symbology/qgis/VBET/norm_hand.qml
@@ -1,0 +1,85 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.18.2-Zürich" maxScale="0" minScale="1e+08" hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <temporal enabled="0" mode="0" fetchMode="0">
+    <fixedRange>
+      <start></start>
+      <end></end>
+    </fixedRange>
+  </temporal>
+  <customproperties>
+    <property key="WMSBackgroundLayer" value="false"/>
+    <property key="WMSPublishDataSourceUrl" value="false"/>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="identify/format" value="Value"/>
+  </customproperties>
+  <pipe>
+    <provider>
+      <resampling maxOversampling="2" enabled="false" zoomedOutResamplingMethod="nearestNeighbour" zoomedInResamplingMethod="nearestNeighbour"/>
+    </provider>
+    <rasterrenderer opacity="0.6" band="1" classificationMax="0.995" nodataColor="" alphaBand="-1" classificationMin="0" type="singlebandpseudocolor">
+      <rasterTransparency/>
+      <minMaxOrigin>
+        <limits>MinMax</limits>
+        <extent>WholeRaster</extent>
+        <statAccuracy>Estimated</statAccuracy>
+        <cumulativeCutLower>0.02</cumulativeCutLower>
+        <cumulativeCutUpper>0.98</cumulativeCutUpper>
+        <stdDevFactor>2</stdDevFactor>
+      </minMaxOrigin>
+      <rastershader>
+        <colorrampshader minimumValue="0" colorRampType="INTERPOLATED" labelPrecision="-10" maximumValue="0.995" classificationMode="1" clip="0">
+          <colorramp name="[source]" type="gradient">
+            <Option type="Map">
+              <Option name="color1" value="252,252,252,255" type="QString"/>
+              <Option name="color2" value="0,77,168,255" type="QString"/>
+              <Option name="discrete" value="0" type="QString"/>
+              <Option name="rampType" value="gradient" type="QString"/>
+              <Option name="stops" value="0.100503;156,156,156,255:0.201005;145,133,104,255:0.301508;242,171,0,255:0.40201;255,229,158,255:0.502513;255,248,199,255:0.683417;195,252,91,255:0.703518;147,219,94,255:0.80402;127,189,93,255:0.854271;121,172,96,255:0.994975;38,115,0,255" type="QString"/>
+            </Option>
+            <prop v="252,252,252,255" k="color1"/>
+            <prop v="0,77,168,255" k="color2"/>
+            <prop v="0" k="discrete"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="0.100503;156,156,156,255:0.201005;145,133,104,255:0.301508;242,171,0,255:0.40201;255,229,158,255:0.502513;255,248,199,255:0.683417;195,252,91,255:0.703518;147,219,94,255:0.80402;127,189,93,255:0.854271;121,172,96,255:0.994975;38,115,0,255" k="stops"/>
+          </colorramp>
+          <item label="0 " value="0" color="#fcfcfc" alpha="255"/>
+          <item label="0 " value="0.1" color="#9c9c9c" alpha="255"/>
+          <item label="0 " value="0.2" color="#918568" alpha="255"/>
+          <item label="0 " value="0.3" color="#f2ab00" alpha="255"/>
+          <item label="0 " value="0.4" color="#ffe59e" alpha="255"/>
+          <item label="0 " value="0.5" color="#fff8c7" alpha="255"/>
+          <item label="0 " value="0.68" color="#c3fc5b" alpha="255"/>
+          <item label="0 " value="0.7" color="#93db5e" alpha="255"/>
+          <item label="0 " value="0.8" color="#7fbd5d" alpha="255"/>
+          <item label="0 " value="0.85" color="#79ac60" alpha="255"/>
+          <item label="0 " value="0.99" color="#267300" alpha="255"/>
+          <item label="0 " value="0.995" color="#004da8" alpha="255"/>
+          <rampLegendSettings direction="0" maximumLabel="" suffix="" prefix="" orientation="2" useContinuousLegend="1" minimumLabel="">
+            <numericFormat id="basic">
+              <Option type="Map">
+                <Option name="decimal_separator" value="" type="QChar"/>
+                <Option name="decimals" value="6" type="int"/>
+                <Option name="rounding_type" value="0" type="int"/>
+                <Option name="show_plus" value="false" type="bool"/>
+                <Option name="show_thousand_separator" value="true" type="bool"/>
+                <Option name="show_trailing_zeros" value="false" type="bool"/>
+                <Option name="thousand_separator" value="" type="QChar"/>
+              </Option>
+            </numericFormat>
+          </rampLegendSettings>
+        </colorrampshader>
+      </rastershader>
+    </rasterrenderer>
+    <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
+    <huesaturation colorizeOn="0" colorizeRed="255" colorizeBlue="128" colorizeGreen="128" colorizeStrength="100" saturation="0" grayscaleMode="0"/>
+    <rasterresampler maxOversampling="2"/>
+    <resamplingStage>resamplingFilter</resamplingStage>
+  </pipe>
+  <blendMode>0</blendMode>
+</qgis>

--- a/Symbology/qgis/VBET/norm_slope.qml
+++ b/Symbology/qgis/VBET/norm_slope.qml
@@ -1,0 +1,78 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.18.2-Zürich" maxScale="0" minScale="1e+08" hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <temporal enabled="0" mode="0" fetchMode="0">
+    <fixedRange>
+      <start></start>
+      <end></end>
+    </fixedRange>
+  </temporal>
+  <customproperties>
+    <property key="WMSBackgroundLayer" value="false"/>
+    <property key="WMSPublishDataSourceUrl" value="false"/>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="identify/format" value="Value"/>
+  </customproperties>
+  <pipe>
+    <provider>
+      <resampling maxOversampling="2" enabled="false" zoomedOutResamplingMethod="nearestNeighbour" zoomedInResamplingMethod="nearestNeighbour"/>
+    </provider>
+    <rasterrenderer opacity="0.6" band="1" classificationMax="0.995" nodataColor="" alphaBand="-1" classificationMin="0" type="singlebandpseudocolor">
+      <rasterTransparency/>
+      <minMaxOrigin>
+        <limits>None</limits>
+        <extent>WholeRaster</extent>
+        <statAccuracy>Estimated</statAccuracy>
+        <cumulativeCutLower>0.02</cumulativeCutLower>
+        <cumulativeCutUpper>0.98</cumulativeCutUpper>
+        <stdDevFactor>2</stdDevFactor>
+      </minMaxOrigin>
+      <rastershader>
+        <colorrampshader minimumValue="0" colorRampType="INTERPOLATED" labelPrecision="4" maximumValue="0.995" classificationMode="1" clip="0">
+          <colorramp name="[source]" type="gradient">
+            <Option type="Map">
+              <Option name="color1" value="255,34,0,255" type="QString"/>
+              <Option name="color2" value="0,97,0,255" type="QString"/>
+              <Option name="discrete" value="0" type="QString"/>
+              <Option name="rampType" value="gradient" type="QString"/>
+              <Option name="stops" value="0.502513;255,153,0,255:0.683417;255,255,0,255:0.80402;123,171,0,255" type="QString"/>
+            </Option>
+            <prop v="255,34,0,255" k="color1"/>
+            <prop v="0,97,0,255" k="color2"/>
+            <prop v="0" k="discrete"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="0.502513;255,153,0,255:0.683417;255,255,0,255:0.80402;123,171,0,255" k="stops"/>
+          </colorramp>
+          <item label="0.0000" value="0" color="#ff2200" alpha="255"/>
+          <item label="0.5000" value="0.5" color="#ff9900" alpha="255"/>
+          <item label="0.6800" value="0.68" color="#ffff00" alpha="255"/>
+          <item label="0.8000" value="0.8" color="#7bab00" alpha="255"/>
+          <item label="0.9950" value="0.995" color="#006100" alpha="255"/>
+          <rampLegendSettings direction="0" maximumLabel="" suffix="" prefix="" orientation="2" useContinuousLegend="1" minimumLabel="">
+            <numericFormat id="basic">
+              <Option type="Map">
+                <Option name="decimal_separator" value="" type="QChar"/>
+                <Option name="decimals" value="6" type="int"/>
+                <Option name="rounding_type" value="0" type="int"/>
+                <Option name="show_plus" value="false" type="bool"/>
+                <Option name="show_thousand_separator" value="true" type="bool"/>
+                <Option name="show_trailing_zeros" value="false" type="bool"/>
+                <Option name="thousand_separator" value="" type="QChar"/>
+              </Option>
+            </numericFormat>
+          </rampLegendSettings>
+        </colorrampshader>
+      </rastershader>
+    </rasterrenderer>
+    <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
+    <huesaturation colorizeOn="0" colorizeRed="255" colorizeBlue="128" colorizeGreen="128" colorizeStrength="100" saturation="0" grayscaleMode="0"/>
+    <rasterresampler maxOversampling="2"/>
+    <resamplingStage>resamplingFilter</resamplingStage>
+  </pipe>
+  <blendMode>0</blendMode>
+</qgis>

--- a/Symbology/qgis/VBET/norm_topo.qml
+++ b/Symbology/qgis/VBET/norm_topo.qml
@@ -1,0 +1,81 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.18.2-Zürich" maxScale="0" minScale="1e+08" hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <temporal enabled="0" mode="0" fetchMode="0">
+    <fixedRange>
+      <start></start>
+      <end></end>
+    </fixedRange>
+  </temporal>
+  <customproperties>
+    <property key="WMSBackgroundLayer" value="false"/>
+    <property key="WMSPublishDataSourceUrl" value="false"/>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="identify/format" value="Value"/>
+  </customproperties>
+  <pipe>
+    <provider>
+      <resampling maxOversampling="2" enabled="false" zoomedOutResamplingMethod="nearestNeighbour" zoomedInResamplingMethod="nearestNeighbour"/>
+    </provider>
+    <rasterrenderer opacity="0.6" band="1" classificationMax="0.995" nodataColor="" alphaBand="-1" classificationMin="0" type="singlebandpseudocolor">
+      <rasterTransparency/>
+      <minMaxOrigin>
+        <limits>None</limits>
+        <extent>WholeRaster</extent>
+        <statAccuracy>Estimated</statAccuracy>
+        <cumulativeCutLower>0.02</cumulativeCutLower>
+        <cumulativeCutUpper>0.98</cumulativeCutUpper>
+        <stdDevFactor>2</stdDevFactor>
+      </minMaxOrigin>
+      <rastershader>
+        <colorrampshader minimumValue="0" colorRampType="INTERPOLATED" labelPrecision="4" maximumValue="0.995" classificationMode="1" clip="0">
+          <colorramp name="[source]" type="gradient">
+            <Option type="Map">
+              <Option name="color1" value="169,129,90,255" type="QString"/>
+              <Option name="color2" value="0,68,27,255" type="QString"/>
+              <Option name="discrete" value="0" type="QString"/>
+              <Option name="rampType" value="gradient" type="QString"/>
+              <Option name="stops" value="0.502513;168,157,109,255:0.683417;131,184,115,255:0.753769;97,187,109,255:0.80402;64,170,92,255:0.854271;35,139,69,255:0.994975;0,109,44,255" type="QString"/>
+            </Option>
+            <prop v="169,129,90,255" k="color1"/>
+            <prop v="0,68,27,255" k="color2"/>
+            <prop v="0" k="discrete"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="0.502513;168,157,109,255:0.683417;131,184,115,255:0.753769;97,187,109,255:0.80402;64,170,92,255:0.854271;35,139,69,255:0.994975;0,109,44,255" k="stops"/>
+          </colorramp>
+          <item label="0.0000" value="0" color="#a9815a" alpha="255"/>
+          <item label="0.5000" value="0.5" color="#a89d6d" alpha="255"/>
+          <item label="0.6800" value="0.68" color="#83b873" alpha="255"/>
+          <item label="0.7500" value="0.75" color="#61bb6d" alpha="255"/>
+          <item label="0.8000" value="0.8" color="#40aa5c" alpha="255"/>
+          <item label="0.8500" value="0.85" color="#238b45" alpha="255"/>
+          <item label="0.9900" value="0.99" color="#006d2c" alpha="255"/>
+          <item label="0.9950" value="0.995" color="#00441b" alpha="255"/>
+          <rampLegendSettings direction="0" maximumLabel="" suffix="" prefix="" orientation="2" useContinuousLegend="1" minimumLabel="">
+            <numericFormat id="basic">
+              <Option type="Map">
+                <Option name="decimal_separator" value="" type="QChar"/>
+                <Option name="decimals" value="6" type="int"/>
+                <Option name="rounding_type" value="0" type="int"/>
+                <Option name="show_plus" value="false" type="bool"/>
+                <Option name="show_thousand_separator" value="true" type="bool"/>
+                <Option name="show_trailing_zeros" value="false" type="bool"/>
+                <Option name="thousand_separator" value="" type="QChar"/>
+              </Option>
+            </numericFormat>
+          </rampLegendSettings>
+        </colorrampshader>
+      </rastershader>
+    </rasterrenderer>
+    <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
+    <huesaturation colorizeOn="0" colorizeRed="255" colorizeBlue="128" colorizeGreen="128" colorizeStrength="100" saturation="0" grayscaleMode="0"/>
+    <rasterresampler maxOversampling="2"/>
+    <resamplingStage>resamplingFilter</resamplingStage>
+  </pipe>
+  <blendMode>0</blendMode>
+</qgis>

--- a/Symbology/qgis/VBET/norm_twi.qml
+++ b/Symbology/qgis/VBET/norm_twi.qml
@@ -1,0 +1,80 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.18.2-Zürich" maxScale="0" minScale="1e+08" hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <temporal enabled="0" mode="0" fetchMode="0">
+    <fixedRange>
+      <start></start>
+      <end></end>
+    </fixedRange>
+  </temporal>
+  <customproperties>
+    <property key="WMSBackgroundLayer" value="false"/>
+    <property key="WMSPublishDataSourceUrl" value="false"/>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="identify/format" value="Value"/>
+  </customproperties>
+  <pipe>
+    <provider>
+      <resampling maxOversampling="2" enabled="false" zoomedOutResamplingMethod="nearestNeighbour" zoomedInResamplingMethod="nearestNeighbour"/>
+    </provider>
+    <rasterrenderer opacity="0.6" band="1" classificationMax="0.995" nodataColor="" alphaBand="-1" classificationMin="0" type="singlebandpseudocolor">
+      <rasterTransparency/>
+      <minMaxOrigin>
+        <limits>None</limits>
+        <extent>WholeRaster</extent>
+        <statAccuracy>Estimated</statAccuracy>
+        <cumulativeCutLower>0.02</cumulativeCutLower>
+        <cumulativeCutUpper>0.98</cumulativeCutUpper>
+        <stdDevFactor>2</stdDevFactor>
+      </minMaxOrigin>
+      <rastershader>
+        <colorrampshader minimumValue="0" colorRampType="INTERPOLATED" labelPrecision="4" maximumValue="0.995" classificationMode="1" clip="0">
+          <colorramp name="[source]" type="gradient">
+            <Option type="Map">
+              <Option name="color1" value="211,137,0,255" type="QString"/>
+              <Option name="color2" value="8,48,107,255" type="QString"/>
+              <Option name="discrete" value="0" type="QString"/>
+              <Option name="rampType" value="gradient" type="QString"/>
+              <Option name="stops" value="0.683417;255,236,176,255:0.753769;107,174,47,255:0.80402;66,146,198,255:0.854271;33,113,181,255:0.994975;8,81,156,255" type="QString"/>
+            </Option>
+            <prop v="211,137,0,255" k="color1"/>
+            <prop v="8,48,107,255" k="color2"/>
+            <prop v="0" k="discrete"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="0.683417;255,236,176,255:0.753769;107,174,47,255:0.80402;66,146,198,255:0.854271;33,113,181,255:0.994975;8,81,156,255" k="stops"/>
+          </colorramp>
+          <item label="0.0000" value="0" color="#d38900" alpha="255"/>
+          <item label="0.6800" value="0.68" color="#ffecb0" alpha="255"/>
+          <item label="0.7500" value="0.75" color="#6bae2f" alpha="255"/>
+          <item label="0.8000" value="0.8" color="#4292c6" alpha="255"/>
+          <item label="0.8500" value="0.85" color="#2171b5" alpha="255"/>
+          <item label="0.9900" value="0.99" color="#08519c" alpha="255"/>
+          <item label="0.9950" value="0.995" color="#08306b" alpha="255"/>
+          <rampLegendSettings direction="0" maximumLabel="" suffix="" prefix="" orientation="2" useContinuousLegend="1" minimumLabel="">
+            <numericFormat id="basic">
+              <Option type="Map">
+                <Option name="decimal_separator" value="" type="QChar"/>
+                <Option name="decimals" value="6" type="int"/>
+                <Option name="rounding_type" value="0" type="int"/>
+                <Option name="show_plus" value="false" type="bool"/>
+                <Option name="show_thousand_separator" value="true" type="bool"/>
+                <Option name="show_trailing_zeros" value="false" type="bool"/>
+                <Option name="thousand_separator" value="" type="QChar"/>
+              </Option>
+            </numericFormat>
+          </rampLegendSettings>
+        </colorrampshader>
+      </rastershader>
+    </rasterrenderer>
+    <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
+    <huesaturation colorizeOn="0" colorizeRed="255" colorizeBlue="128" colorizeGreen="128" colorizeStrength="100" saturation="0" grayscaleMode="0"/>
+    <rasterresampler maxOversampling="2"/>
+    <resamplingStage>resamplingFilter</resamplingStage>
+  </pipe>
+  <blendMode>0</blendMode>
+</qgis>


### PR DESCRIPTION
This pull request includes four .qml files for the normalized evidence rasters used in VBET projects.

**Normalized HAND:**
<img width="1046" alt="norm_hand" src="https://user-images.githubusercontent.com/73311751/130303839-798068b5-0c51-4486-95d5-713443364f0e.PNG">
<img width="1044" alt="norm_hand2" src="https://user-images.githubusercontent.com/73311751/130303840-c2468df2-afb8-4110-991d-a98a2f693420.PNG">

**Normalized TWI:**
<img width="1044" alt="norm_twi" src="https://user-images.githubusercontent.com/73311751/130303846-12eab8de-2d2c-4b6c-87d9-6ddb69d79a9a.PNG">
<img width="1046" alt="norm_twi2" src="https://user-images.githubusercontent.com/73311751/130303861-91b6d5ec-c989-4a4f-9f70-79a01c9a41b4.PNG">

**Normalized Slope:**
<img width="1046" alt="norm_slope" src="https://user-images.githubusercontent.com/73311751/130303870-da66e71a-f21e-4418-8980-cba25ae0e705.PNG">
<img width="1046" alt="norm_slope2" src="https://user-images.githubusercontent.com/73311751/130303872-55346aec-a577-43d9-93cf-bbe2c7735add.PNG">

**Normalized Topographic Evidence:**
<img width="1047" alt="norm_topo" src="https://user-images.githubusercontent.com/73311751/130303880-73e7b11a-c239-4f6a-b2c8-5a6b5c0948f0.PNG">
<img width="1046" alt="norm_topo2" src="https://user-images.githubusercontent.com/73311751/130303881-0a0cd71b-b6e7-477b-ab48-bbad288f0a42.PNG">