### PR TITLE
Minor Tweaks to TauDEM Business Logic & D∞ Slope Analysis Symbology

### DIFF
--- a/RaveBusinessLogic/TauDEM.xml
+++ b/RaveBusinessLogic/TauDEM.xml
@@ -25,7 +25,7 @@
                             <Node label="TauDEM Report" xpath="HTMLFile[@id='REPORT']" type="file" />
                             <Node label="D∞ Slope Analysis (percent)" xpath="Outputs/Raster[@id='DINFFLOWDIR_SLP']" type="raster" symbology="dinfflowdir_slp" transparency="40" />
                             <Node label="Basic Grid Analysis">
-                                <Children collapsed="true">
+                                <Children collapsed="false">
                                     <Node label="Pit-filled DEM" xpath="Intermediates/Raster[@id='PITFILL']" type="raster" symbology="dem" transparency="40" />
                                     <Node label="D∞ Flow Directions (bearing)" xpath="Intermediates/Raster[@id='DINFFLOWDIR_ANG']" type="raster" symbology="dinfflowdir_ang" transparency="40" />
                                     <Node label="D∞ Contributing Area" xpath="Intermediates/Raster[@id='AREADINF_SCA']" type="raster" symbology="areadinf_sca" transparency="40" id="ca"/>
@@ -41,7 +41,7 @@
                     </Node>
                     <Node label="GDAL Outputs">
                         <Children>
-                             <Node label="D8 Slope Analysis (degrees)" xpath="Outputs/Raster[@id='GDAL_SLOPE']" type="raster" symbology="slope" transparency="40" id="d8_slope" />
+                             <Node label="D8 Slope Analysis (degrees)" xpath="Intermediates/Raster[@id='GDAL_SLOPE']" type="raster" symbology="slope" transparency="40" id="d8_slope" />
                         </Children>
                     </Node>
                 </Children>

--- a/Symbology/qgis/TauDEM/dinfflowdir_slp.qml
+++ b/Symbology/qgis/TauDEM/dinfflowdir_slp.qml
@@ -22,7 +22,7 @@
     <provider>
       <resampling zoomedInResamplingMethod="nearestNeighbour" enabled="false" zoomedOutResamplingMethod="nearestNeighbour" maxOversampling="2"/>
     </provider>
-    <rasterrenderer opacity="0.6" classificationMax="0.58" nodataColor="" band="1" classificationMin="0" alphaBand="-1" type="singlebandpseudocolor">
+    <rasterrenderer opacity="0.6" classificationMax="1" nodataColor="" band="1" classificationMin="0" alphaBand="-1" type="singlebandpseudocolor">
       <rasterTransparency/>
       <minMaxOrigin>
         <limits>None</limits>
@@ -33,26 +33,26 @@
         <stdDevFactor>2</stdDevFactor>
       </minMaxOrigin>
       <rastershader>
-        <colorrampshader classificationMode="1" maximumValue="0.58" clip="0" labelPrecision="2" minimumValue="0" colorRampType="INTERPOLATED">
+        <colorrampshader classificationMode="1" maximumValue="1" clip="0" labelPrecision="4" minimumValue="0" colorRampType="DISCRETE">
           <colorramp name="[source]" type="gradient">
             <Option type="Map">
               <Option value="0,97,0,255" name="color1" type="QString"/>
               <Option value="255,34,0,255" name="color2" type="QString"/>
               <Option value="0" name="discrete" type="QString"/>
               <Option value="gradient" name="rampType" type="QString"/>
-              <Option value="0.155172;123,171,0,255:0.310345;255,255,0,255:0.62069;255,153,0,255" name="stops" type="QString"/>
+              <Option value="0.09;0,97,0,255:0.18;123,171,0,255:0.36;255,255,0,255:0.58;255,162,0,255" name="stops" type="QString"/>
             </Option>
             <prop k="color1" v="0,97,0,255"/>
             <prop k="color2" v="255,34,0,255"/>
             <prop k="discrete" v="0"/>
             <prop k="rampType" v="gradient"/>
-            <prop k="stops" v="0.155172;123,171,0,255:0.310345;255,255,0,255:0.62069;255,153,0,255"/>
+            <prop k="stops" v="0.09;0,97,0,255:0.18;123,171,0,255:0.36;255,255,0,255:0.58;255,162,0,255"/>
           </colorramp>
-          <item label="0.00" alpha="255" value="0" color="#006100"/>
-          <item label="0.09" alpha="255" value="0.09" color="#7bab00"/>
-          <item label="0.18" alpha="255" value="0.18" color="#ffff00"/>
-          <item label="0.36" alpha="255" value="0.36" color="#ff9900"/>
-          <item label="0.58" alpha="255" value="0.58" color="#ff2200"/>
+          <item label="0 - 0.1" alpha="255" value="0.09" color="#006100"/>
+          <item label="0.1 - 0.2" alpha="255" value="0.18" color="#7bab00"/>
+          <item label="0.2 - 0.4" alpha="255" value="0.36" color="#ffff00"/>
+          <item label="0.4 - 0.6" alpha="255" value="0.58" color="#ffa200"/>
+          <item label="> 0.6" alpha="255" value="1" color="#ff2200"/>
           <rampLegendSettings direction="0" suffix="" minimumLabel="" maximumLabel="" orientation="2" prefix="" useContinuousLegend="1">
             <numericFormat id="basic">
               <Option type="Map">

--- a/Symbology/qgis/TauDEM/dinfflowdir_slp.qml
+++ b/Symbology/qgis/TauDEM/dinfflowdir_slp.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="3.18.2-Zürich" minScale="1e+08" maxScale="0" hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories">
+<qgis minScale="1e+08" maxScale="0" version="3.18.2-Zürich" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -13,16 +13,16 @@
     </fixedRange>
   </temporal>
   <customproperties>
-    <property key="WMSBackgroundLayer" value="false"/>
-    <property key="WMSPublishDataSourceUrl" value="false"/>
-    <property key="embeddedWidgets/count" value="0"/>
-    <property key="identify/format" value="Value"/>
+    <property value="false" key="WMSBackgroundLayer"/>
+    <property value="false" key="WMSPublishDataSourceUrl"/>
+    <property value="0" key="embeddedWidgets/count"/>
+    <property value="Value" key="identify/format"/>
   </customproperties>
   <pipe>
     <provider>
-      <resampling zoomedOutResamplingMethod="nearestNeighbour" zoomedInResamplingMethod="nearestNeighbour" maxOversampling="2" enabled="false"/>
+      <resampling zoomedInResamplingMethod="nearestNeighbour" enabled="false" zoomedOutResamplingMethod="nearestNeighbour" maxOversampling="2"/>
     </provider>
-    <rasterrenderer type="singlebandpseudocolor" band="1" opacity="0.6" nodataColor="" classificationMax="0.5" classificationMin="0" alphaBand="-1">
+    <rasterrenderer opacity="0.6" classificationMax="0.5" nodataColor="" band="1" classificationMin="0" alphaBand="-1" type="singlebandpseudocolor">
       <rasterTransparency/>
       <minMaxOrigin>
         <limits>None</limits>
@@ -33,38 +33,38 @@
         <stdDevFactor>2</stdDevFactor>
       </minMaxOrigin>
       <rastershader>
-        <colorrampshader classificationMode="1" clip="0" labelPrecision="4" minimumValue="0" colorRampType="INTERPOLATED" maximumValue="0.5">
+        <colorrampshader classificationMode="1" maximumValue="0.5" clip="0" labelPrecision="4" minimumValue="0" colorRampType="INTERPOLATED">
           <colorramp name="[source]" type="gradient">
             <Option type="Map">
-              <Option name="color1" type="QString" value="215,25,28,255"/>
-              <Option name="color2" type="QString" value="73,177,79,255"/>
-              <Option name="discrete" type="QString" value="0"/>
-              <Option name="rampType" type="QString" value="gradient"/>
-              <Option name="stops" type="QString" value="0.04;221,49,39,255:0.1;231,84,55,255:0.2;246,144,83,255:0.3;254,190,116,255:0.6;222,242,180,255"/>
+              <Option value="73,177,79,255" name="color1" type="QString"/>
+              <Option value="215,25,28,255" name="color2" type="QString"/>
+              <Option value="0" name="discrete" type="QString"/>
+              <Option value="gradient" name="rampType" type="QString"/>
+              <Option value="0.1;222,242,180,255:0.2;254,190,116,255:0.3;246,144,83,255:0.4;231,84,55,255:0.6;221,49,39,255" name="stops" type="QString"/>
             </Option>
-            <prop k="color1" v="215,25,28,255"/>
-            <prop k="color2" v="73,177,79,255"/>
+            <prop k="color1" v="73,177,79,255"/>
+            <prop k="color2" v="215,25,28,255"/>
             <prop k="discrete" v="0"/>
             <prop k="rampType" v="gradient"/>
-            <prop k="stops" v="0.04;221,49,39,255:0.1;231,84,55,255:0.2;246,144,83,255:0.3;254,190,116,255:0.6;222,242,180,255"/>
+            <prop k="stops" v="0.1;222,242,180,255:0.2;254,190,116,255:0.3;246,144,83,255:0.4;231,84,55,255:0.6;221,49,39,255"/>
           </colorramp>
-          <item color="#d7191c" label="0.0000" value="0" alpha="255"/>
-          <item color="#dd3127" label="0.0200" value="0.02" alpha="255"/>
-          <item color="#e75437" label="0.0500" value="0.05" alpha="255"/>
-          <item color="#f69053" label="0.1000" value="0.1" alpha="255"/>
-          <item color="#febe74" label="0.1500" value="0.15" alpha="255"/>
-          <item color="#def2b4" label="0.3000" value="0.3" alpha="255"/>
-          <item color="#49b14f" label="0.5000" value="0.5" alpha="255"/>
-          <rampLegendSettings maximumLabel="" useContinuousLegend="1" prefix="" suffix="" minimumLabel="" direction="0" orientation="2">
+          <item label="0.0000" alpha="255" value="0" color="#49b14f"/>
+          <item label="0.0500" alpha="255" value="0.05" color="#def2b4"/>
+          <item label="0.1000" alpha="255" value="0.1" color="#febe74"/>
+          <item label="0.1500" alpha="255" value="0.15" color="#f69053"/>
+          <item label="0.2000" alpha="255" value="0.2" color="#e75437"/>
+          <item label="0.3000" alpha="255" value="0.3" color="#dd3127"/>
+          <item label="0.5000" alpha="255" value="0.5" color="#d7191c"/>
+          <rampLegendSettings direction="0" suffix="" minimumLabel="" maximumLabel="" orientation="2" prefix="" useContinuousLegend="1">
             <numericFormat id="basic">
               <Option type="Map">
-                <Option name="decimal_separator" type="QChar" value=""/>
-                <Option name="decimals" type="int" value="6"/>
-                <Option name="rounding_type" type="int" value="0"/>
-                <Option name="show_plus" type="bool" value="false"/>
-                <Option name="show_thousand_separator" type="bool" value="true"/>
-                <Option name="show_trailing_zeros" type="bool" value="false"/>
-                <Option name="thousand_separator" type="QChar" value=""/>
+                <Option value="" name="decimal_separator" type="QChar"/>
+                <Option value="6" name="decimals" type="int"/>
+                <Option value="0" name="rounding_type" type="int"/>
+                <Option value="false" name="show_plus" type="bool"/>
+                <Option value="true" name="show_thousand_separator" type="bool"/>
+                <Option value="false" name="show_trailing_zeros" type="bool"/>
+                <Option value="" name="thousand_separator" type="QChar"/>
               </Option>
             </numericFormat>
           </rampLegendSettings>
@@ -72,7 +72,7 @@
       </rastershader>
     </rasterrenderer>
     <brightnesscontrast contrast="0" gamma="1" brightness="0"/>
-    <huesaturation colorizeRed="255" saturation="0" grayscaleMode="0" colorizeOn="0" colorizeStrength="100" colorizeBlue="128" colorizeGreen="128"/>
+    <huesaturation colorizeOn="0" colorizeBlue="128" colorizeGreen="128" grayscaleMode="0" saturation="0" colorizeRed="255" colorizeStrength="100"/>
     <rasterresampler maxOversampling="2"/>
     <resamplingStage>resamplingFilter</resamplingStage>
   </pipe>

--- a/Symbology/qgis/TauDEM/dinfflowdir_slp.qml
+++ b/Symbology/qgis/TauDEM/dinfflowdir_slp.qml
@@ -22,7 +22,7 @@
     <provider>
       <resampling zoomedInResamplingMethod="nearestNeighbour" enabled="false" zoomedOutResamplingMethod="nearestNeighbour" maxOversampling="2"/>
     </provider>
-    <rasterrenderer opacity="0.6" classificationMax="0.5" nodataColor="" band="1" classificationMin="0" alphaBand="-1" type="singlebandpseudocolor">
+    <rasterrenderer opacity="0.6" classificationMax="0.58" nodataColor="" band="1" classificationMin="0" alphaBand="-1" type="singlebandpseudocolor">
       <rasterTransparency/>
       <minMaxOrigin>
         <limits>None</limits>
@@ -33,28 +33,26 @@
         <stdDevFactor>2</stdDevFactor>
       </minMaxOrigin>
       <rastershader>
-        <colorrampshader classificationMode="1" maximumValue="0.5" clip="0" labelPrecision="4" minimumValue="0" colorRampType="INTERPOLATED">
+        <colorrampshader classificationMode="1" maximumValue="0.58" clip="0" labelPrecision="2" minimumValue="0" colorRampType="INTERPOLATED">
           <colorramp name="[source]" type="gradient">
             <Option type="Map">
-              <Option value="73,177,79,255" name="color1" type="QString"/>
-              <Option value="215,25,28,255" name="color2" type="QString"/>
+              <Option value="0,97,0,255" name="color1" type="QString"/>
+              <Option value="255,34,0,255" name="color2" type="QString"/>
               <Option value="0" name="discrete" type="QString"/>
               <Option value="gradient" name="rampType" type="QString"/>
-              <Option value="0.1;222,242,180,255:0.2;254,190,116,255:0.3;246,144,83,255:0.4;231,84,55,255:0.6;221,49,39,255" name="stops" type="QString"/>
+              <Option value="0.155172;123,171,0,255:0.310345;255,255,0,255:0.62069;255,153,0,255" name="stops" type="QString"/>
             </Option>
-            <prop k="color1" v="73,177,79,255"/>
-            <prop k="color2" v="215,25,28,255"/>
+            <prop k="color1" v="0,97,0,255"/>
+            <prop k="color2" v="255,34,0,255"/>
             <prop k="discrete" v="0"/>
             <prop k="rampType" v="gradient"/>
-            <prop k="stops" v="0.1;222,242,180,255:0.2;254,190,116,255:0.3;246,144,83,255:0.4;231,84,55,255:0.6;221,49,39,255"/>
+            <prop k="stops" v="0.155172;123,171,0,255:0.310345;255,255,0,255:0.62069;255,153,0,255"/>
           </colorramp>
-          <item label="0.0000" alpha="255" value="0" color="#49b14f"/>
-          <item label="0.0500" alpha="255" value="0.05" color="#def2b4"/>
-          <item label="0.1000" alpha="255" value="0.1" color="#febe74"/>
-          <item label="0.1500" alpha="255" value="0.15" color="#f69053"/>
-          <item label="0.2000" alpha="255" value="0.2" color="#e75437"/>
-          <item label="0.3000" alpha="255" value="0.3" color="#dd3127"/>
-          <item label="0.5000" alpha="255" value="0.5" color="#d7191c"/>
+          <item label="0.00" alpha="255" value="0" color="#006100"/>
+          <item label="0.09" alpha="255" value="0.09" color="#7bab00"/>
+          <item label="0.18" alpha="255" value="0.18" color="#ffff00"/>
+          <item label="0.36" alpha="255" value="0.36" color="#ff9900"/>
+          <item label="0.58" alpha="255" value="0.58" color="#ff2200"/>
           <rampLegendSettings direction="0" suffix="" minimumLabel="" maximumLabel="" orientation="2" prefix="" useContinuousLegend="1">
             <numericFormat id="basic">
               <Option type="Map">


### PR DESCRIPTION
Includes updates to business logic to get things looking and working correctly again after some recent updates. D∞ slope symbology updated to match our existing slope appearance.

Here is the updated D∞ Slope Analysis (percent) symbology:
<img width="1136" alt="dinfflowdir_slp" src="https://user-images.githubusercontent.com/73311751/132787277-ed37703b-d8ea-49cb-89cc-4bd2a6c1e1b9.PNG">

 You'll notice that the legend shows decimals instead of degrees like the slope we're used to seeing. I converted degrees to percents and forced breaks at the equivalent values. I'm curious if you'd rather see them as "0 - 10%, 10 - 20%, etc" rather than decimals? If so, it's a quick label fix.