### PR TITLE
Fixing BL for VBET to handle new naming. 

### DIFF
--- a/RaveBusinessLogic/VBET.xml
+++ b/RaveBusinessLogic/VBET.xml
@@ -9,8 +9,12 @@
       <Node label="Outputs" xpath="Outputs">
         <Children>
           <Node label="Likelihood of being Valley Bottom" xpath="Raster[@id='VBET_EVIDENCE']" type="raster" symbology="vbetLikelihood" transparency="40" id="likevbet" />
+          <!-- These are the names from pre https://github.com/Riverscapes/riverscapes-tools/issues/427 fixes -->
           <Node label="Valley Bottom Extent (Hollow)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet68_hollow" id="vbet_extent_hollow" />               
           <Node label="Valley Bottom Extent (Filled)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet68_filled" transparency="40" id="vbet_extent_filled" />              
+          <!-- These are the new naming convention -->
+          <Node label="Valley Bottom Extent (Hollow)" xpath="Geopackage/Layers/Vector[@id='VBET_FULL']" type="polygon" symbology="vbet68_hollow" id="vbet_extent_hollow" />               
+          <Node label="Valley Bottom Extent (Filled)" xpath="Geopackage/Layers/Vector[@id='VBET_FULL']" type="polygon" symbology="vbet68_filled" transparency="40" id="vbet_extent_filled" />   
           <Node label="Valley Bottom Geomorphic Units">
             <Children>
               <Node label="Estimated Active Channel" xpath="Geopackage/Layers/Vector[@id='VBET_CHANNEL_AREA']" type="polygon" symbology="vbet_channel_area" id="vbet_channel_area" />                        


### PR DESCRIPTION
This accommodates the new VBET output naming convention of #427, while (for now) accommodating the old naming convention in VBET project files as well.

@philipbaileynar and I discussed the various strategies we could adopt here. In the long-term, if we delete and/or replace all existing VBET projects, we can get rid of the old lines (13 & 14):
https://github.com/Riverscapes/RiverscapesXML/blob/9b9c4d7152509fc0594a0b7047e2aa339cef42bc/RaveBusinessLogic/VBET.xml#L12-L15

However, for now we decided to just put both in like @philipbaileynar did with sqlBRAT for a while, so projects folks currently have on disc will still work.  

Thanks @KellyMWhitehead for making this easy and writing a [vbet.xml in the project](https://northarrowresearchlabs.github.io/riverscapes-staging/#/Anabranch/418b1e7b-8897-4773-9f75-b23a9ff9825a) that worked with new one. Made this copy and paste so simple. 