### PR TITLE
Consistency Updates

### DIFF
--- a/RaveBusinessLogic/BRAT.xml
+++ b/RaveBusinessLogic/BRAT.xml
@@ -25,7 +25,7 @@
               <Node label="Restoration or Conservation Opportunities" xpath="Geopackage/Layers/Vector[@id='BRAT_RESULTS']" type="line" symbology="opportunity" id="opportunity" />
             </Children>
           </Node>
-          <Node label="BRAT Outputs Geopackage (SQLite Database)" xpath="Geopackage" type="file" /> 
+          <Node label="Outputs Geopackage (SQLite Database)" xpath="Geopackage" type="file" /> 
         </Children>
       </Node>
       <Node label="Intermediates" xpath="Realizations/BRAT/Outputs">
@@ -75,7 +75,7 @@
               <Node label="Distance to Canals/Ditches" xpath="Geopackage/Layers/Vector[@id='BRAT_RESULTS']" type="line" symbology="iPC_Canal" />
             </Children>
           </Node>
-          <Node label="BRAT Intermediates Geopackage (SQLite Database)" xpath="Geopackage" type="file" /> 
+          <Node label="Intermediates Geopackage (SQLite Database)" xpath="Geopackage" type="file" /> 
         </Children>
       </Node>
       <Node label="Inputs" xpath="Realizations/BRAT/Inputs">
@@ -114,7 +114,7 @@
               <Node label="Hillshade" xpath="Raster[@id='HILLSHADE']" type="raster" symbology="Hillshade" id="hillshade" />
             </Children>
           </Node>
-          <Node label="BRAT Inputs Geopackage (SQLite Database)" xpath="Geopackage" type="file" /> 
+          <Node label="Inputs Geopackage (SQLite Database)" xpath="Geopackage" type="file" /> 
         </Children>
       </Node>
       <Node label="Log File" xpath="Realizations/BRAT/LogFile" type="file" />

--- a/RaveBusinessLogic/BRAT.xml
+++ b/RaveBusinessLogic/BRAT.xml
@@ -117,6 +117,7 @@
           <Node label="BRAT Inputs Geopackage (SQLite Database)" xpath="Geopackage" type="file" /> 
         </Children>
       </Node>
+      <Node label="Log File" xpath="Realizations/BRAT/LogFile" type="file" />
     </Children>
   </Node>
   <Views default="BRAT_exOutputs">

--- a/RaveBusinessLogic/BRAT.xml
+++ b/RaveBusinessLogic/BRAT.xml
@@ -8,6 +8,7 @@
       <Node label="Project Report"  xpath="Realizations/BRAT/Outputs/HTMLFile" type="report" />
       <Node label="Outputs" xpath="Realizations/BRAT/Outputs">
         <Children collapsed="true">
+          <!-- The SQLite DB is no longer present, but left this for some of the legacy projects. TODO - Remove when all sqlBRAT projects replaced.-->
           <Node xpathlabel="Name" xpath="SQLiteDB" type="file" />
           <Node label="Capacity">
             <Children>

--- a/RaveBusinessLogic/BRAT.xml
+++ b/RaveBusinessLogic/BRAT.xml
@@ -5,10 +5,10 @@
   <ProjectType>BRAT</ProjectType>
   <Node xpathlabel="Name">
     <Children collapsed="false">
+      <Node label="Project Report"  xpath="Realizations/BRAT/Outputs/HTMLFile" type="report" />
       <Node label="Outputs" xpath="Realizations/BRAT/Outputs">
         <Children collapsed="true">
           <Node xpathlabel="Name" xpath="SQLiteDB" type="file" />
-          <Node xpathlabel="Name" xpath="HTMLFile" type="report" />
           <Node label="Capacity">
             <Children>
               <Node label="Existing Dam Capacity" xpath="Geopackage/Layers/Vector[@id='BRAT_RESULTS']" type="line" symbology="oCC_EX" id="ex_capacity" />

--- a/RaveBusinessLogic/ChannelArea.xml
+++ b/RaveBusinessLogic/ChannelArea.xml
@@ -11,6 +11,7 @@
                   <Node label="NHD Flowlines" xpath="Geopackage/Layers/Vector[@id='FLOWLINES']" type="line" id="flowlines" symbology="FLOWLINES" />
                   <Node label="NHD Flow Areas" xpath="Geopackage/Layers/Vector[@id='FLOWAREAS']" type="polygon" id="flowareas" symbology="FLOWAREAS" />
                   <Node label="NHD Waterbody Areas" xpath="Geopackage/Layers/Vector[@id='WATER_BODIES']" type="polygon" id="waterbodies" symbology="WATER_BODIES" />
+                  <Node label="Inputs Geopackage (SQLite Database)" xpath="Geopackage" type="file" /> 
                 </Children>
             </Node>
             <Node label="Intermediates" xpath="Intermediates">
@@ -22,13 +23,14 @@
                   <Node label="Bankfull Network" xpath="Geopackage/Layers/Vector[@id='BANKFULL_NETWORK']" type="polygon" id="bankfull_network" symbology="BANKFULL_NETWORK" />
                   <Node label="Bankfull Polygons" xpath="Geopackage/Layers/Vector[@id='BANKFULL_POLYGONS']" type="polygon" id="bankfull_polygons" symbology="BANKFULL_POLYGONS" />
                   <Node label="Difference Polygons" xpath="Geopackage/Layers/Vector[@id='DIFFERENCE_POLYGONS']" type="polygon" id="difference_polygons" symbology="DIFFERENCE_POLYGONS" />
+                  <Node label="Intermediates Geopackage (SQLite Database)" xpath="Geopackage" type="file" /> 
                 </Children>
             </Node>
             <Node label="Outputs" xpath="Outputs">
                 <Children collapsed="false">
                   <Node label="Channel Area (hollow)" xpath="Geopackage/Layers/Vector[@id='CHANNEL_AREA']" type="polygon" id="channel_area" symbology="ChannelArea_hollow" />
                   <Node label="Channel Area (filled)" xpath="Geopackage/Layers/Vector[@id='CHANNEL_AREA']" type="polygon" id="channel_area" symbology="ChannelArea" />
-                  <Node label="Channel Area Project Report" xpath="HTMLFile[@id='REPORT']" type="report" />  
+                  <Node label="Outputs Geopackage (SQLite Database)" xpath="Geopackage" type="file" /> 
                 </Children>
             </Node>
             <Node label="Log File" xpath="LogFile" type="file" />

--- a/RaveBusinessLogic/ChannelArea.xml
+++ b/RaveBusinessLogic/ChannelArea.xml
@@ -5,8 +5,7 @@
     <ProjectType>ChannelArea</ProjectType>
     <Node xpathlabel="Name" xpath="Realizations/ChannelArea">
         <Children collapsed="false">
-            
-            
+            <Node label="Project Report" xpath="Outputs/HTMLFile[@id='REPORT']" type="report" />  
             <Node label="Inputs" xpath="Inputs">
                 <Children collapsed="true">
                   <Node label="NHD Flowlines" xpath="Geopackage/Layers/Vector[@id='FLOWLINES']" type="line" id="flowlines" symbology="FLOWLINES" />
@@ -32,7 +31,7 @@
                   <Node label="Channel Area Project Report" xpath="HTMLFile[@id='REPORT']" type="report" />  
                 </Children>
             </Node>
-            <Node label="Channel Area Log File" xpath="LogFile" type="file" />
+            <Node label="Log File" xpath="LogFile" type="file" />
         </Children>
     </Node>
     <Views default="DEFAULT">

--- a/RaveBusinessLogic/ChannelArea.xml
+++ b/RaveBusinessLogic/ChannelArea.xml
@@ -5,6 +5,8 @@
     <ProjectType>ChannelArea</ProjectType>
     <Node xpathlabel="Name" xpath="Realizations/ChannelArea">
         <Children collapsed="false">
+            
+            
             <Node label="Inputs" xpath="Inputs">
                 <Children collapsed="true">
                   <Node label="NHD Flowlines" xpath="Geopackage/Layers/Vector[@id='FLOWLINES']" type="line" id="flowlines" symbology="FLOWLINES" />
@@ -27,8 +29,10 @@
                 <Children collapsed="false">
                   <Node label="Channel Area (hollow)" xpath="Geopackage/Layers/Vector[@id='CHANNEL_AREA']" type="polygon" id="channel_area" symbology="ChannelArea_hollow" />
                   <Node label="Channel Area (filled)" xpath="Geopackage/Layers/Vector[@id='CHANNEL_AREA']" type="polygon" id="channel_area" symbology="ChannelArea" />
+                  <Node label="Channel Area Project Report" xpath="HTMLFile[@id='REPORT']" type="report" />  
                 </Children>
             </Node>
+            <Node label="Channel Area Log File" xpath="LogFile" type="file" />
         </Children>
     </Node>
     <Views default="DEFAULT">

--- a/RaveBusinessLogic/Confinement.xml
+++ b/RaveBusinessLogic/Confinement.xml
@@ -7,28 +7,32 @@
     <Children collapsed="false">
       <Node label="Project Report" xpath="Outputs/HTMLFile" type="report" />
       <Node label="Outputs">
-        <Children collapsed="false">
+        <Children collapsed="true">
           <Node label="Confinement Type" xpathlabel="Name" xpath="Outputs/Geopackage/Layers/Vector[@id='CONFINEMENT_RAW']" type="line" id="confinement_raw" symbology="confinement_raw" />
           <Node label="Confining Margins" xpathlabel="Name" xpath="Outputs/Geopackage/Layers/Vector[@id='CONFINEMENT_MARGINS']" type="line" id="confinement_margins" symbology="confinement_margins" />
           <Node xpathlabel="Name" xpath="Outputs/Geopackage/Layers/Vector[@id='CONFINEMENT_RATIO']" type="line" id="confinement_ratio" symbology="confinement_ratio" />
           <Node label="Constriction Proportion" xpath="Outputs/Geopackage/Layers/Vector[@id='CONFINEMENT_RATIO']" type="line" id="constriction_ratio" symbology="constriction_ratio" />
           <Node xpathlabel="Name" xpath="Outputs/Geopackage/Layers/Vector[@id='CONFINEMENT_BUFFERS']" type="line" id="confinement_buffer" symbology="confinement_buffer" />
+          <Node label="Outputs Geopackage (SQLite Database)" xpath="Outputs/Geopackage" type="file" /> 
         </Children>
       </Node>
-      <Node label="Context (Inputs)">
-        <Children collapsed="true">
-            <Node xpathlabel="Name" xpath="Inputs/Geopackage/Layers/Vector[@id='FLOWLINES']" type="line" symbology="flowlines" />
-            <Node label="Valley Bottom Polygon" xpathlabel="Name" xpath="Inputs/Geopackage/Layers/Vector[@id='CONFINING_POLYGON']" type="polygon" id="confining_poly" symbology="confining_poly" transparency="60"/>
-        </Children>
-      </Node>
-      <Node label="Calculations (Intermediates)">
+      <Node label="Intermediates">
         <Children collapsed="true">
           <Node xpathlabel="Name" xpath="Intermediates/Geopackage/Layers/Vector[@id='SPLIT_POINTS']" type="point" symbology="split_points" />
           <Node xpathlabel="Name" xpath="Intermediates/Geopackage/Layers/Vector[@id='FLOWLINE_SEGMENTS']" type="line" symbology="flowline_segments" />
           <Node xpathlabel="Name" xpath="Intermediates/Geopackage/Layers/Vector[@id='ERROR_POLYLINES']" type="line" symbology="error_polylines" />
           <Node xpathlabel="Name" xpath="Intermediates/Geopackage/Layers/Vector[@id='ERROR_POLYGONS']" type="polygon" symbology="error_polygons" />
+          <Node label="Intermediates Geopackage (SQLite Database)" xpath="Intermediates/Geopackage" type="file" /> 
         </Children>
       </Node>
+      <Node label="Inputs">
+        <Children collapsed="true">
+            <Node xpathlabel="Name" xpath="Inputs/Geopackage/Layers/Vector[@id='FLOWLINES']" type="line" symbology="flowlines" />
+            <Node label="Valley Bottom Polygon" xpathlabel="Name" xpath="Inputs/Geopackage/Layers/Vector[@id='CONFINING_POLYGON']" type="polygon" id="confining_poly" symbology="confining_poly" transparency="60"/>
+            <Node label="Inputs Geopackage (SQLite Database)" xpath="Inputs/Geopackage" type="file" /> 
+          </Children>
+      </Node>
+      <Node label="Log File" xpath="LogFile" type="file" />
     </Children>
   </Node>
 

--- a/RaveBusinessLogic/Confinement.xml
+++ b/RaveBusinessLogic/Confinement.xml
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://xml.riverscapes.xyz/RaveBusinessLogic/XSD/project_explorer.xsd">
   <!-- <Project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="./XSD/project_explorer.xsd"> -->
   <Name>Confinement</Name>
   <ProjectType>CONFINEMENT</ProjectType>
   <Node xpathlabel="Name" xpath="Realizations/Confinement">
     <Children collapsed="false">
-      <Node xpathlabel="Name" xpath="Outputs/HTMLFile" type="report" />
+      <Node label="Project Report" xpath="Outputs/HTMLFile" type="report" />
       <Node label="Outputs">
         <Children collapsed="false">
           <Node label="Confinement Type" xpathlabel="Name" xpath="Outputs/Geopackage/Layers/Vector[@id='CONFINEMENT_RAW']" type="line" id="confinement_raw" symbology="confinement_raw" />

--- a/RaveBusinessLogic/RSContext.xml
+++ b/RaveBusinessLogic/RSContext.xml
@@ -8,8 +8,8 @@
       <Node label="Project Report" xpath="HTMLFile[@id='REPORT']" type="report" />
       <Node label="Transportation Local">
         <Children collapsed="true">
-          <Node xpathlabel="Name" xpath="Vector[@id='Roads']" type="line" symbology="roads" />
-          <Node xpathlabel="Name" xpath="Vector[@id='Rail']" type="line" symbology="railroads" />
+          <Node xpathlabel="Name" xpath="Vector[@id='Roads']" type="line" symbology="roads" id="roads" />
+          <Node xpathlabel="Name" xpath="Vector[@id='Rail']" type="line" symbology="railroads" id="railroads"/>
         </Children>
       </Node>
       <Node label="Hydrology">
@@ -112,21 +112,28 @@
           <Node xpathlabel="Name" xpath="Raster[@id='HILLSHADE']" type="raster" symbology="hillshade" id="hs" />
         </Children>
       </Node>
+      <Node label="Log File" xpath="LogFile" type="file" />
     </Children>
   </Node>
   <Views default="Default">
-    <View name="Default View" id="Default">
+    <View name="Hydrology" id="Default">
       <Layers>
         <Layer id="huc8" />
         <Layer id="perrenial" />
         <Layer id="hs" />
       </Layers>
     </View>
-    <View name="Topography View" id="Topography">
+    <View name="Topography" id="Topography">
       <Layers>
         <Layer id="perrenial" />
         <Layer id="dem" />
         <Layer id="hs" />
+      </Layers>
+    </View>
+    <View name="Transportation" id="Transportation">
+      <Layers>
+        <Layer id="roads" />
+        <Layer id="railroads" />
       </Layers>
     </View>
   </Views>

--- a/RaveBusinessLogic/RSContext.xml
+++ b/RaveBusinessLogic/RSContext.xml
@@ -5,8 +5,7 @@
   <ProjectType>RSContext</ProjectType>
   <Node xpathlabel="Name" xpath="Realizations/RSContext">
     <Children collapsed="false">
-      <Node xpathlabel="Name" xpath="HTMLFile[@id='REPORT']" type="report" />
-      <Node xpathlabel="Name" xpath="LogFile" type="file" />
+      <Node label="Project Report" xpath="HTMLFile[@id='REPORT']" type="report" />
       <Node label="Transportation Local">
         <Children collapsed="true">
           <Node xpathlabel="Name" xpath="Vector[@id='Roads']" type="line" symbology="roads" />

--- a/RaveBusinessLogic/TauDEM.xml
+++ b/RaveBusinessLogic/TauDEM.xml
@@ -46,6 +46,7 @@
                     </Node>
                 </Children>
             </Node>
+            <Node label="Log File" xpath="LogFile" type="file" />
         </Children>
     </Node>
     <Views default="DEFAULT">

--- a/RaveBusinessLogic/TauDEM.xml
+++ b/RaveBusinessLogic/TauDEM.xml
@@ -11,6 +11,7 @@
                   <Node label="Channel Line Input" xpath="Geopackage/Layers/Vector[@id='CHANNEL_LINES']" type="line" symbology="channel_line_network" id="channel_line" />
                   <Node label="DEM" xpath="Raster[@id='DEM']" type="raster" symbology="dem" transparency="40" id="dem" />
                   <Node label="DEM Hillshade" xpath="Raster[@id='HILLSHADE']" type="raster" symbology="hillshade" id="hillshade" />
+                  <Node label="Inputs Geopackage (SQLite Database)" xpath="Geopackage" type="file" /> 
                 </Children>
             </Node>
             <Node label="Intermediates" xpath="Intermediates">

--- a/RaveBusinessLogic/TauDEM.xml
+++ b/RaveBusinessLogic/TauDEM.xml
@@ -5,6 +5,7 @@
     <ProjectType>TauDEM</ProjectType>
     <Node xpathlabel="Name" xpath="Realizations/TauDEM">
         <Children collapsed="false">
+             <Node label="Project Report"  xpath="Outputs/HTMLFile" type="report" />
              <Node label="Inputs" xpath="Inputs">
                 <Children collapsed="true">
                   <Node label="Channel Area" xpath="Geopackage/Layers/Vector[@id='CHANNEL_AREA']" type="polygon"  symbology="ChannelArea" id="channel_area" />

--- a/RaveBusinessLogic/VBET.xml
+++ b/RaveBusinessLogic/VBET.xml
@@ -6,8 +6,9 @@
   <ProjectType>VBET</ProjectType>
   <Node xpathlabel="Name" xpath="Realizations/VBET">
     <Children collapsed="false">
+      <Node label="Project Report" xpath="Outputs/HTMLFile" type="report" />
       <Node label="Outputs" xpath="Outputs">
-        <Children>
+        <Children collapsed="true">
           <Node label="Likelihood of being Valley Bottom" xpath="Raster[@id='VBET_EVIDENCE']" type="raster" symbology="vbetLikelihood" transparency="40" id="likevbet" />
           <!-- These are the names from pre https://github.com/Riverscapes/riverscapes-tools/issues/427 fixes -->
           <Node label="Valley Bottom Extent (Hollow)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet68_hollow" id="vbet_extent_hollow" />               
@@ -16,25 +17,19 @@
           <Node label="Valley Bottom Extent (Hollow)" xpath="Geopackage/Layers/Vector[@id='VBET_FULL']" type="polygon" symbology="vbet68_hollow" id="vbet_extent_hollow" />               
           <Node label="Valley Bottom Extent (Filled)" xpath="Geopackage/Layers/Vector[@id='VBET_FULL']" type="polygon" symbology="vbet68_filled" transparency="40" id="vbet_extent_filled" />   
           <Node label="Valley Bottom Geomorphic Units">
-            <Children>
+            <Children collapsed="false">
               <Node label="Estimated Active Channel" xpath="Geopackage/Layers/Vector[@id='VBET_CHANNEL_AREA']" type="polygon" symbology="vbet_channel_area" id="vbet_channel_area" />                        
               <Node label="Estimated Active Floodplain" xpath="Geopackage/Layers/Vector[@id='ACTIVE_FLOODPLAIN']" type="polygon" symbology="vbet_active_floodplain" id="vbet_active_floodplain"/>
               <Node label="Estimated Inactive Floodplain" xpath="Geopackage/Layers/Vector[@id='INACTIVE_FLOODPLAIN']" type="polygon" symbology="vbet_inactive_floodplain" id="vbet_inactive_floodplain"/>      
             </Children>
           </Node>
+          <Node label="Outputs Geopackage (SQLite Database)" xpath="Geopackage" type="file" />
         </Children>
       </Node>
-      <Node label="Inputs" xpath="Inputs">
-          <Children>
-            <Node label="Channel Area Polygons" xpath="Geopackage/Layers/Vector[@id='CHANNEL_AREA_POLYGONS']" type="polygon" id="channel_area_polygons" symbology="ChannelArea" />
-            <Node label="Digital Elevation Model" xpath="Raster[@id='DEM']" type="raster" symbology="dem" transparency="40" id="dem" />
-            <Node label="DEM Hillshade" xpath="Raster[@id='HILLSHADE']" type="raster" symbology="hillshade" id="hillshade" />
-          </Children>
-      </Node>
       <Node label="Intermediates">
-        <Children>
+        <Children collapsed="true">
           <Node label="Evidence Rasters">
-            <Children>
+            <Children collapsed="true">
               <Node label="Slope Raster" xpath="Inputs/Raster[@id='SLOPE_RASTER']" type="raster" symbology="slope" transparency="40" />
               <Node label="HAND Raster" xpath="Inputs/Raster[@id='HAND_RASTER']" type="raster" symbology="hand" transparency="40" />
               <Node label="TWI Raster" xpath="Inputs/Raster[@id='TWI_RASTER']" type="raster" symbology="twi" transparency="40" />
@@ -42,22 +37,40 @@
             </Children>
           </Node>
           <Node label="Normalized Evidence Rasters" xpath="Intermediates">
-            <Children>
+            <Children collapsed="false">
               <Node label="Normalized Slope Evidence" xpath="Raster[@id='NORMALIZED_SLOPE']" type="raster" symbology="norm_slope" transparency="40" />
               <Node label="Normalized HAND Evidence" xpath="Raster[@id='NORMALIZED_HAND']" type="raster" symbology="norm_hand" transparency="40" />
               <Node label="Normalized TWI Evidence" xpath="Raster[@id='NORMALIZED_TWI']" type="raster" symbology="norm_twi" transparency="40" />
               <Node label="Combined Topographic Evidence" xpath="Raster[@id='EVIDENCE_TOPO']" type="raster" symbology="norm_topo" transparency="40" id="norm_topo" />
             </Children>
           </Node>
+          <Node label="Transform Zones" xpath="Intermediates">
+            <Children collapsed="true">
+              <!-- This is waiting for next round to be exposed in projects.
+                <Node label="Catchment Wings" xpath="Layers/Vector[@id='CATCHMENTS_DISSOLVED']" type="polygon" /> -->
+              <Node label="Catchment Wing Stream Order" xpath="Geopackage/Layers/Vector[@id='TRANSFORM_ZONES']" type="polygon" symbology="CWingStreamOrder" transparency="40" />
+              <Node label="Intermediates Geopackage (SQLite Database)" xpath="Geopackage" type="file" />
+            </Children>
+          </Node>
+          
         </Children>
       </Node>
+      <Node label="Inputs" xpath="Inputs">
+          <Children collapsed="true">
+            <Node label="Channel Area Polygons" xpath="Geopackage/Layers/Vector[@id='CHANNEL_AREA_POLYGONS']" type="polygon" id="channel_area_polygons" symbology="ChannelArea" />
+            <Node label="Digital Elevation Model" xpath="Raster[@id='DEM']" type="raster" symbology="dem" transparency="40" id="dem" />
+            <Node label="DEM Hillshade" xpath="Raster[@id='HILLSHADE']" type="raster" symbology="hillshade" id="hillshade" />
+            <Node label="Inputs Geopackage (SQLite Database)" xpath="Geopackage" type="file" />
+          </Children>     
+      </Node>
+      <Node label="Log File" xpath="LogFile" type="file" />
     </Children>
   </Node>
   <Views default="DEFAULT">
     <View name="Primary Output" id="DEFAULT">
       <Layers>
-        <Layer id="likevbet" />
         <Layer id="vbet_extent_hollow" />
+        <Layer id="likevbet" />
         <Layer id="hillshade" />
       </Layers>
     </View>

--- a/Symbology/qgis/Shared/dem.qml
+++ b/Symbology/qgis/Shared/dem.qml
@@ -22,7 +22,7 @@
     <provider>
       <resampling enabled="false" maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" zoomedInResamplingMethod="nearestNeighbour"/>
     </provider>
-    <rasterrenderer opacity="0.6" alphaBand="-1" classificationMax="2279.018310546875" type="singlebandpseudocolor" band="1" classificationMin="1306.34228515625" nodataColor="">
+    <rasterrenderer opacity="0.4" alphaBand="-1" classificationMax="2279.018310546875" type="singlebandpseudocolor" band="1" classificationMin="1306.34228515625" nodataColor="">
       <rasterTransparency/>
       <minMaxOrigin>
         <limits>MinMax</limits>

--- a/Symbology/qgis/Shared/hand.qml
+++ b/Symbology/qgis/Shared/hand.qml
@@ -22,7 +22,7 @@
     <provider>
       <resampling enabled="false" maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" zoomedInResamplingMethod="nearestNeighbour"/>
     </provider>
-    <rasterrenderer alphaBand="-1" opacity="0.6" classificationMin="0" classificationMax="361.6794739" type="singlebandpseudocolor" nodataColor="" band="1">
+    <rasterrenderer alphaBand="-1" opacity="0.4" classificationMin="0" classificationMax="361.6794739" type="singlebandpseudocolor" nodataColor="" band="1">
       <rasterTransparency/>
       <minMaxOrigin>
         <limits>MinMax</limits>

--- a/Symbology/qgis/Shared/slope.qml
+++ b/Symbology/qgis/Shared/slope.qml
@@ -22,7 +22,7 @@
     <provider>
       <resampling maxOversampling="2" zoomedInResamplingMethod="nearestNeighbour" enabled="false" zoomedOutResamplingMethod="nearestNeighbour"/>
     </provider>
-    <rasterrenderer classificationMin="0" type="singlebandpseudocolor" band="1" nodataColor="" classificationMax="30" opacity="0.6" alphaBand="-1">
+    <rasterrenderer classificationMin="0" type="singlebandpseudocolor" band="1" nodataColor="" classificationMax="30" opacity="0.4" alphaBand="-1">
       <rasterTransparency/>
       <minMaxOrigin>
         <limits>None</limits>

--- a/Symbology/qgis/Shared/twi.qml
+++ b/Symbology/qgis/Shared/twi.qml
@@ -22,7 +22,7 @@
     <provider>
       <resampling zoomedOutResamplingMethod="nearestNeighbour" zoomedInResamplingMethod="nearestNeighbour" maxOversampling="2" enabled="false"/>
     </provider>
-    <rasterrenderer type="singlebandpseudocolor" band="1" opacity="0.6" nodataColor="" classificationMax="30" classificationMin="0" alphaBand="-1">
+    <rasterrenderer type="singlebandpseudocolor" band="1" opacity="0.4" nodataColor="" classificationMax="30" classificationMin="0" alphaBand="-1">
       <rasterTransparency/>
       <minMaxOrigin>
         <limits>None</limits>

--- a/Symbology/qgis/VBET/CwingStreamOrder.qml
+++ b/Symbology/qgis/VBET/CwingStreamOrder.qml
@@ -1,0 +1,1048 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="Symbology|Labeling|Legend" labelsEnabled="1" version="3.20.2-Odense">
+  <renderer-v2 type="categorizedSymbol" symbollevels="0" enableorderby="0" attr="StreamOrde" forceraster="0">
+    <categories>
+      <category value="1" label="1" render="true" symbol="0"/>
+      <category value="2" label="2" render="true" symbol="1"/>
+      <category value="3" label="3" render="true" symbol="2"/>
+      <category value="4" label="4" render="true" symbol="3"/>
+      <category value="5" label="5" render="true" symbol="4"/>
+      <category value="6" label="6" render="true" symbol="5"/>
+      <category value="" label="" render="true" symbol="6"/>
+    </categories>
+    <symbols>
+      <symbol type="fill" name="0" clip_to_extent="1" force_rhr="0" alpha="0.5">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="color" value="11,4,5,255"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="offset" value="0,0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="outline_color" value="35,35,35,255"/>
+            <Option type="QString" name="outline_style" value="no"/>
+            <Option type="QString" name="outline_width" value="0.26"/>
+            <Option type="QString" name="outline_width_unit" value="MM"/>
+            <Option type="QString" name="style" value="dense7"/>
+          </Option>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="11,4,5,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="no"/>
+          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="dense7"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="align_dash_pattern" value="0"/>
+            <Option type="QString" name="capstyle" value="square"/>
+            <Option type="QString" name="customdash" value="5;2"/>
+            <Option type="QString" name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="customdash_unit" value="MM"/>
+            <Option type="QString" name="dash_pattern_offset" value="0"/>
+            <Option type="QString" name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="dash_pattern_offset_unit" value="MM"/>
+            <Option type="QString" name="draw_inside_polygon" value="0"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="line_color" value="11,4,5,255"/>
+            <Option type="QString" name="line_style" value="solid"/>
+            <Option type="QString" name="line_width" value="0.26"/>
+            <Option type="QString" name="line_width_unit" value="MM"/>
+            <Option type="QString" name="offset" value="0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="ring_filter" value="0"/>
+            <Option type="QString" name="trim_distance_end" value="0"/>
+            <Option type="QString" name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_end_unit" value="MM"/>
+            <Option type="QString" name="trim_distance_start" value="0"/>
+            <Option type="QString" name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_start_unit" value="MM"/>
+            <Option type="QString" name="tweak_dash_pattern_on_corners" value="0"/>
+            <Option type="QString" name="use_custom_dash" value="0"/>
+            <Option type="QString" name="width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+          </Option>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="11,4,5,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.26"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol type="fill" name="1" clip_to_extent="1" force_rhr="0" alpha="0.5">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="color" value="52,36,70,255"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="offset" value="0,0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="outline_color" value="35,35,35,255"/>
+            <Option type="QString" name="outline_style" value="no"/>
+            <Option type="QString" name="outline_width" value="0.26"/>
+            <Option type="QString" name="outline_width_unit" value="MM"/>
+            <Option type="QString" name="style" value="dense6"/>
+          </Option>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="52,36,70,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="no"/>
+          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="dense6"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="align_dash_pattern" value="0"/>
+            <Option type="QString" name="capstyle" value="square"/>
+            <Option type="QString" name="customdash" value="5;2"/>
+            <Option type="QString" name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="customdash_unit" value="MM"/>
+            <Option type="QString" name="dash_pattern_offset" value="0"/>
+            <Option type="QString" name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="dash_pattern_offset_unit" value="MM"/>
+            <Option type="QString" name="draw_inside_polygon" value="0"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="line_color" value="52,36,70,255"/>
+            <Option type="QString" name="line_style" value="solid"/>
+            <Option type="QString" name="line_width" value="0.26"/>
+            <Option type="QString" name="line_width_unit" value="MM"/>
+            <Option type="QString" name="offset" value="0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="ring_filter" value="0"/>
+            <Option type="QString" name="trim_distance_end" value="0"/>
+            <Option type="QString" name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_end_unit" value="MM"/>
+            <Option type="QString" name="trim_distance_start" value="0"/>
+            <Option type="QString" name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_start_unit" value="MM"/>
+            <Option type="QString" name="tweak_dash_pattern_on_corners" value="0"/>
+            <Option type="QString" name="use_custom_dash" value="0"/>
+            <Option type="QString" name="width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+          </Option>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="52,36,70,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.26"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol type="fill" name="2" clip_to_extent="1" force_rhr="0" alpha="0.5">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="color" value="64,73,142,255"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="offset" value="0,0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="outline_color" value="35,35,35,255"/>
+            <Option type="QString" name="outline_style" value="no"/>
+            <Option type="QString" name="outline_width" value="0.26"/>
+            <Option type="QString" name="outline_width_unit" value="MM"/>
+            <Option type="QString" name="style" value="dense5"/>
+          </Option>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="64,73,142,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="no"/>
+          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="dense5"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="align_dash_pattern" value="0"/>
+            <Option type="QString" name="capstyle" value="square"/>
+            <Option type="QString" name="customdash" value="5;2"/>
+            <Option type="QString" name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="customdash_unit" value="MM"/>
+            <Option type="QString" name="dash_pattern_offset" value="0"/>
+            <Option type="QString" name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="dash_pattern_offset_unit" value="MM"/>
+            <Option type="QString" name="draw_inside_polygon" value="0"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="line_color" value="64,73,142,255"/>
+            <Option type="QString" name="line_style" value="solid"/>
+            <Option type="QString" name="line_width" value="0.26"/>
+            <Option type="QString" name="line_width_unit" value="MM"/>
+            <Option type="QString" name="offset" value="0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="ring_filter" value="0"/>
+            <Option type="QString" name="trim_distance_end" value="0"/>
+            <Option type="QString" name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_end_unit" value="MM"/>
+            <Option type="QString" name="trim_distance_start" value="0"/>
+            <Option type="QString" name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_start_unit" value="MM"/>
+            <Option type="QString" name="tweak_dash_pattern_on_corners" value="0"/>
+            <Option type="QString" name="use_custom_dash" value="0"/>
+            <Option type="QString" name="width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+          </Option>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="64,73,142,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.26"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol type="fill" name="3" clip_to_extent="1" force_rhr="0" alpha="0.5">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="color" value="53,123,163,255"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="offset" value="0,0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="outline_color" value="35,35,35,255"/>
+            <Option type="QString" name="outline_style" value="no"/>
+            <Option type="QString" name="outline_width" value="0.26"/>
+            <Option type="QString" name="outline_width_unit" value="MM"/>
+            <Option type="QString" name="style" value="dense5"/>
+          </Option>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="53,123,163,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="no"/>
+          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="dense5"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="align_dash_pattern" value="0"/>
+            <Option type="QString" name="capstyle" value="square"/>
+            <Option type="QString" name="customdash" value="5;2"/>
+            <Option type="QString" name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="customdash_unit" value="MM"/>
+            <Option type="QString" name="dash_pattern_offset" value="0"/>
+            <Option type="QString" name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="dash_pattern_offset_unit" value="MM"/>
+            <Option type="QString" name="draw_inside_polygon" value="0"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="line_color" value="53,123,163,255"/>
+            <Option type="QString" name="line_style" value="solid"/>
+            <Option type="QString" name="line_width" value="0.26"/>
+            <Option type="QString" name="line_width_unit" value="MM"/>
+            <Option type="QString" name="offset" value="0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="ring_filter" value="0"/>
+            <Option type="QString" name="trim_distance_end" value="0"/>
+            <Option type="QString" name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_end_unit" value="MM"/>
+            <Option type="QString" name="trim_distance_start" value="0"/>
+            <Option type="QString" name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_start_unit" value="MM"/>
+            <Option type="QString" name="tweak_dash_pattern_on_corners" value="0"/>
+            <Option type="QString" name="use_custom_dash" value="0"/>
+            <Option type="QString" name="width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+          </Option>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="53,123,163,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.26"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol type="fill" name="4" clip_to_extent="1" force_rhr="0" alpha="0.5">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="color" value="57,171,172,255"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="offset" value="0,0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="outline_color" value="35,35,35,255"/>
+            <Option type="QString" name="outline_style" value="no"/>
+            <Option type="QString" name="outline_width" value="0.26"/>
+            <Option type="QString" name="outline_width_unit" value="MM"/>
+            <Option type="QString" name="style" value="dense5"/>
+          </Option>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="57,171,172,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="no"/>
+          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="dense5"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="align_dash_pattern" value="0"/>
+            <Option type="QString" name="capstyle" value="square"/>
+            <Option type="QString" name="customdash" value="5;2"/>
+            <Option type="QString" name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="customdash_unit" value="MM"/>
+            <Option type="QString" name="dash_pattern_offset" value="0"/>
+            <Option type="QString" name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="dash_pattern_offset_unit" value="MM"/>
+            <Option type="QString" name="draw_inside_polygon" value="0"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="line_color" value="57,171,172,255"/>
+            <Option type="QString" name="line_style" value="solid"/>
+            <Option type="QString" name="line_width" value="0.26"/>
+            <Option type="QString" name="line_width_unit" value="MM"/>
+            <Option type="QString" name="offset" value="0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="ring_filter" value="0"/>
+            <Option type="QString" name="trim_distance_end" value="0"/>
+            <Option type="QString" name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_end_unit" value="MM"/>
+            <Option type="QString" name="trim_distance_start" value="0"/>
+            <Option type="QString" name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_start_unit" value="MM"/>
+            <Option type="QString" name="tweak_dash_pattern_on_corners" value="0"/>
+            <Option type="QString" name="use_custom_dash" value="0"/>
+            <Option type="QString" name="width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+          </Option>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="57,171,172,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.26"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol type="fill" name="5" clip_to_extent="1" force_rhr="0" alpha="0.5">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="color" value="122,214,174,255"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="offset" value="0,0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="outline_color" value="35,35,35,255"/>
+            <Option type="QString" name="outline_style" value="no"/>
+            <Option type="QString" name="outline_width" value="0.26"/>
+            <Option type="QString" name="outline_width_unit" value="MM"/>
+            <Option type="QString" name="style" value="dense5"/>
+          </Option>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="122,214,174,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="no"/>
+          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="dense5"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="align_dash_pattern" value="0"/>
+            <Option type="QString" name="capstyle" value="square"/>
+            <Option type="QString" name="customdash" value="5;2"/>
+            <Option type="QString" name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="customdash_unit" value="MM"/>
+            <Option type="QString" name="dash_pattern_offset" value="0"/>
+            <Option type="QString" name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="dash_pattern_offset_unit" value="MM"/>
+            <Option type="QString" name="draw_inside_polygon" value="0"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="line_color" value="122,214,174,255"/>
+            <Option type="QString" name="line_style" value="solid"/>
+            <Option type="QString" name="line_width" value="0.26"/>
+            <Option type="QString" name="line_width_unit" value="MM"/>
+            <Option type="QString" name="offset" value="0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="ring_filter" value="0"/>
+            <Option type="QString" name="trim_distance_end" value="0"/>
+            <Option type="QString" name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_end_unit" value="MM"/>
+            <Option type="QString" name="trim_distance_start" value="0"/>
+            <Option type="QString" name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_start_unit" value="MM"/>
+            <Option type="QString" name="tweak_dash_pattern_on_corners" value="0"/>
+            <Option type="QString" name="use_custom_dash" value="0"/>
+            <Option type="QString" name="width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+          </Option>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="122,214,174,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.26"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol type="fill" name="6" clip_to_extent="1" force_rhr="0" alpha="0.5">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="color" value="222,245,229,255"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="offset" value="0,0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="outline_color" value="35,35,35,255"/>
+            <Option type="QString" name="outline_style" value="no"/>
+            <Option type="QString" name="outline_width" value="0.26"/>
+            <Option type="QString" name="outline_width_unit" value="MM"/>
+            <Option type="QString" name="style" value="dense5"/>
+          </Option>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="222,245,229,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="no"/>
+          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="dense5"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="align_dash_pattern" value="0"/>
+            <Option type="QString" name="capstyle" value="square"/>
+            <Option type="QString" name="customdash" value="5;2"/>
+            <Option type="QString" name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="customdash_unit" value="MM"/>
+            <Option type="QString" name="dash_pattern_offset" value="0"/>
+            <Option type="QString" name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="dash_pattern_offset_unit" value="MM"/>
+            <Option type="QString" name="draw_inside_polygon" value="0"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="line_color" value="222,245,229,255"/>
+            <Option type="QString" name="line_style" value="solid"/>
+            <Option type="QString" name="line_width" value="0.26"/>
+            <Option type="QString" name="line_width_unit" value="MM"/>
+            <Option type="QString" name="offset" value="0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="ring_filter" value="0"/>
+            <Option type="QString" name="trim_distance_end" value="0"/>
+            <Option type="QString" name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_end_unit" value="MM"/>
+            <Option type="QString" name="trim_distance_start" value="0"/>
+            <Option type="QString" name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_start_unit" value="MM"/>
+            <Option type="QString" name="tweak_dash_pattern_on_corners" value="0"/>
+            <Option type="QString" name="use_custom_dash" value="0"/>
+            <Option type="QString" name="width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+          </Option>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="222,245,229,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.26"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <source-symbol>
+      <symbol type="fill" name="0" clip_to_extent="1" force_rhr="0" alpha="0.5">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="color" value="0,77,168,255"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="offset" value="0,0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="outline_color" value="35,35,35,255"/>
+            <Option type="QString" name="outline_style" value="no"/>
+            <Option type="QString" name="outline_width" value="0.26"/>
+            <Option type="QString" name="outline_width_unit" value="MM"/>
+            <Option type="QString" name="style" value="dense5"/>
+          </Option>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="0,77,168,255"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="no"/>
+          <prop k="outline_width" v="0.26"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="dense5"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer locked="0" class="SimpleLine" pass="0" enabled="1">
+          <Option type="Map">
+            <Option type="QString" name="align_dash_pattern" value="0"/>
+            <Option type="QString" name="capstyle" value="square"/>
+            <Option type="QString" name="customdash" value="5;2"/>
+            <Option type="QString" name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="customdash_unit" value="MM"/>
+            <Option type="QString" name="dash_pattern_offset" value="0"/>
+            <Option type="QString" name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="dash_pattern_offset_unit" value="MM"/>
+            <Option type="QString" name="draw_inside_polygon" value="0"/>
+            <Option type="QString" name="joinstyle" value="bevel"/>
+            <Option type="QString" name="line_color" value="35,35,35,255"/>
+            <Option type="QString" name="line_style" value="solid"/>
+            <Option type="QString" name="line_width" value="0.26"/>
+            <Option type="QString" name="line_width_unit" value="MM"/>
+            <Option type="QString" name="offset" value="0"/>
+            <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="offset_unit" value="MM"/>
+            <Option type="QString" name="ring_filter" value="0"/>
+            <Option type="QString" name="trim_distance_end" value="0"/>
+            <Option type="QString" name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_end_unit" value="MM"/>
+            <Option type="QString" name="trim_distance_start" value="0"/>
+            <Option type="QString" name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+            <Option type="QString" name="trim_distance_start_unit" value="MM"/>
+            <Option type="QString" name="tweak_dash_pattern_on_corners" value="0"/>
+            <Option type="QString" name="use_custom_dash" value="0"/>
+            <Option type="QString" name="width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+          </Option>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="square"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="35,35,35,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.26"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" name="name" value=""/>
+              <Option name="properties"/>
+              <Option type="QString" name="type" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </source-symbol>
+    <colorramp type="gradient" name="[source]">
+      <Option type="Map">
+        <Option type="QString" name="color1" value="11,4,5,255"/>
+        <Option type="QString" name="color2" value="222,245,229,255"/>
+        <Option type="QString" name="discrete" value="0"/>
+        <Option type="QString" name="rampType" value="gradient"/>
+        <Option type="QString" name="stops" value="0.0039063;13,4,6,255:0.0078125;14,5,8,255:0.0117188;15,6,9,255:0.015625;16,6,10,255:0.0195313;17,7,12,255:0.0234375;18,8,13,255:0.0273438;19,9,15,255:0.03125;20,9,16,255:0.0351563;21,10,18,255:0.0390625;22,11,19,255:0.0429688;23,12,21,255:0.046875;24,13,22,255:0.0507813;25,14,24,255:0.0546875;26,14,25,255:0.0585938;27,15,26,255:0.0625;28,16,28,255:0.0664063;29,17,29,255:0.0703125;30,17,31,255:0.0742188;31,18,32,255:0.078125;32,19,34,255:0.0820313;33,20,35,255:0.0859375;34,20,37,255:0.0898438;35,21,38,255:0.09375;36,22,40,255:0.0976563;37,23,41,255:0.101563;38,23,43,255:0.105469;39,24,45,255:0.109375;40,25,46,255:0.113281;41,25,48,255:0.117188;41,26,49,255:0.121094;42,27,51,255:0.125;43,28,53,255:0.128906;44,28,54,255:0.132813;45,29,56,255:0.136719;46,30,57,255:0.140625;46,30,59,255:0.144531;47,31,61,255:0.148438;48,32,62,255:0.152344;49,33,64,255:0.15625;49,33,66,255:0.160156;50,34,67,255:0.164063;51,35,69,255:0.167969;52,36,71,255:0.171875;52,37,72,255:0.175781;53,37,74,255:0.179688;53,38,76,255:0.183594;54,39,77,255:0.1875;55,40,79,255:0.191406;55,40,81,255:0.195313;56,41,83,255:0.199219;56,42,84,255:0.203125;57,43,86,255:0.207031;58,44,88,255:0.210938;58,44,89,255:0.214844;59,45,91,255:0.21875;59,46,93,255:0.222656;59,47,95,255:0.226563;60,48,96,255:0.230469;60,49,98,255:0.234375;61,49,100,255:0.238281;61,50,102,255:0.242188;62,51,103,255:0.246094;62,52,105,255:0.25;62,53,107,255:0.253906;63,54,109,255:0.257813;63,54,111,255:0.261719;63,55,112,255:0.265625;64,56,114,255:0.269531;64,57,116,255:0.273438;64,58,118,255:0.277344;64,59,120,255:0.28125;64,60,121,255:0.285156;65,61,123,255:0.289063;65,62,125,255:0.292969;65,62,127,255:0.296875;65,63,128,255:0.300781;65,64,130,255:0.304688;65,65,132,255:0.308594;65,66,133,255:0.3125;65,67,135,255:0.316406;65,68,136,255:0.320313;64,70,138,255:0.324219;64,71,139,255:0.328125;64,72,141,255:0.332031;64,73,142,255:0.335938;63,74,143,255:0.339844;63,75,144,255:0.34375;63,76,146,255:0.347656;62,77,147,255:0.351563;62,79,148,255:0.355469;62,80,149,255:0.359375;61,81,149,255:0.363281;61,82,150,255:0.367188;60,83,151,255:0.371094;60,85,152,255:0.375;59,86,152,255:0.378906;59,87,153,255:0.382813;59,88,154,255:0.386719;58,89,154,255:0.390625;58,91,155,255:0.394531;58,92,155,255:0.398438;57,93,156,255:0.402344;57,94,156,255:0.40625;56,95,156,255:0.410156;56,97,157,255:0.414063;56,98,157,255:0.417969;56,99,157,255:0.421875;55,100,158,255:0.425781;55,101,158,255:0.429688;55,102,158,255:0.433594;55,104,159,255:0.4375;54,105,159,255:0.441406;54,106,159,255:0.445313;54,107,159,255:0.449219;54,108,160,255:0.453125;54,109,160,255:0.457031;54,111,160,255:0.460938;54,112,160,255:0.464844;54,113,160,255:0.46875;53,114,161,255:0.472656;53,115,161,255:0.476563;53,116,161,255:0.480469;53,117,161,255:0.484375;53,118,162,255:0.488281;53,120,162,255:0.492188;53,121,162,255:0.496094;53,122,162,255:0.5;53,123,163,255:0.503906;53,124,163,255:0.507813;53,125,163,255:0.511719;53,126,164,255:0.515625;52,127,164,255:0.519531;52,128,164,255:0.523438;52,130,164,255:0.527344;52,131,165,255:0.53125;52,132,165,255:0.535156;52,133,165,255:0.539063;52,134,165,255:0.542969;52,135,166,255:0.546875;52,136,166,255:0.550781;52,137,166,255:0.554688;52,139,166,255:0.558594;52,140,167,255:0.5625;52,141,167,255:0.566406;52,142,167,255:0.570313;52,143,167,255:0.574219;52,144,168,255:0.578125;52,145,168,255:0.582031;52,146,168,255:0.585938;52,147,168,255:0.589844;52,149,169,255:0.59375;52,150,169,255:0.597656;52,151,169,255:0.601563;52,152,169,255:0.605469;52,153,170,255:0.609375;52,154,170,255:0.613281;53,155,170,255:0.617188;53,156,170,255:0.621094;53,158,170,255:0.625;53,159,171,255:0.628906;53,160,171,255:0.632813;53,161,171,255:0.636719;54,162,171,255:0.640625;54,163,171,255:0.644531;54,164,171,255:0.648438;55,165,172,255:0.652344;55,166,172,255:0.65625;55,168,172,255:0.660156;56,169,172,255:0.664063;56,170,172,255:0.667969;57,171,172,255:0.671875;57,172,172,255:0.675781;58,173,172,255:0.679688;58,174,173,255:0.683594;59,175,173,255:0.6875;60,177,173,255:0.691406;60,178,173,255:0.695313;61,179,173,255:0.699219;62,180,173,255:0.703125;63,181,173,255:0.707031;63,182,173,255:0.710938;64,183,173,255:0.714844;65,184,173,255:0.71875;66,185,173,255:0.722656;67,186,173,255:0.726563;68,188,173,255:0.730469;69,189,173,255:0.734375;70,190,173,255:0.738281;71,191,173,255:0.742188;72,192,173,255:0.746094;73,193,173,255:0.75;75,194,173,255:0.753906;76,195,173,255:0.757813;77,196,173,255:0.761719;79,197,173,255:0.765625;80,198,173,255:0.769531;82,199,173,255:0.773438;83,201,173,255:0.777344;85,202,173,255:0.78125;87,203,173,255:0.785156;89,204,173,255:0.789063;91,205,173,255:0.792969;94,205,173,255:0.796875;96,206,172,255:0.800781;98,207,172,255:0.804688;101,208,173,255:0.808594;104,209,173,255:0.8125;106,210,173,255:0.816406;109,211,173,255:0.820313;112,212,173,255:0.824219;115,212,173,255:0.828125;118,213,174,255:0.832031;121,214,174,255:0.835938;124,214,175,255:0.839844;127,215,175,255:0.84375;130,216,176,255:0.847656;133,217,177,255:0.851563;136,217,177,255:0.855469;139,218,178,255:0.859375;142,219,179,255:0.863281;145,219,180,255:0.867188;148,220,181,255:0.871094;150,221,181,255:0.875;153,221,182,255:0.878906;156,222,183,255:0.882813;158,223,184,255:0.886719;161,223,185,255:0.890625;164,224,187,255:0.894531;166,225,188,255:0.898438;169,225,189,255:0.902344;171,226,190,255:0.90625;174,227,192,255:0.910156;176,228,193,255:0.914063;178,228,194,255:0.917969;181,229,196,255:0.921875;183,230,197,255:0.925781;185,230,199,255:0.929688;187,231,200,255:0.933594;190,232,202,255:0.9375;192,233,204,255:0.941406;194,233,205,255:0.945313;196,234,207,255:0.949219;198,235,209,255:0.953125;200,236,210,255:0.957031;202,237,212,255:0.960938;204,237,214,255:0.964844;206,238,215,255:0.96875;208,239,217,255:0.972656;210,240,219,255:0.976563;212,241,220,255:0.980469;214,241,222,255:0.984375;216,242,224,255:0.988281;218,243,225,255"/>
+      </Option>
+      <prop k="color1" v="11,4,5,255"/>
+      <prop k="color2" v="222,245,229,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.0039063;13,4,6,255:0.0078125;14,5,8,255:0.0117188;15,6,9,255:0.015625;16,6,10,255:0.0195313;17,7,12,255:0.0234375;18,8,13,255:0.0273438;19,9,15,255:0.03125;20,9,16,255:0.0351563;21,10,18,255:0.0390625;22,11,19,255:0.0429688;23,12,21,255:0.046875;24,13,22,255:0.0507813;25,14,24,255:0.0546875;26,14,25,255:0.0585938;27,15,26,255:0.0625;28,16,28,255:0.0664063;29,17,29,255:0.0703125;30,17,31,255:0.0742188;31,18,32,255:0.078125;32,19,34,255:0.0820313;33,20,35,255:0.0859375;34,20,37,255:0.0898438;35,21,38,255:0.09375;36,22,40,255:0.0976563;37,23,41,255:0.101563;38,23,43,255:0.105469;39,24,45,255:0.109375;40,25,46,255:0.113281;41,25,48,255:0.117188;41,26,49,255:0.121094;42,27,51,255:0.125;43,28,53,255:0.128906;44,28,54,255:0.132813;45,29,56,255:0.136719;46,30,57,255:0.140625;46,30,59,255:0.144531;47,31,61,255:0.148438;48,32,62,255:0.152344;49,33,64,255:0.15625;49,33,66,255:0.160156;50,34,67,255:0.164063;51,35,69,255:0.167969;52,36,71,255:0.171875;52,37,72,255:0.175781;53,37,74,255:0.179688;53,38,76,255:0.183594;54,39,77,255:0.1875;55,40,79,255:0.191406;55,40,81,255:0.195313;56,41,83,255:0.199219;56,42,84,255:0.203125;57,43,86,255:0.207031;58,44,88,255:0.210938;58,44,89,255:0.214844;59,45,91,255:0.21875;59,46,93,255:0.222656;59,47,95,255:0.226563;60,48,96,255:0.230469;60,49,98,255:0.234375;61,49,100,255:0.238281;61,50,102,255:0.242188;62,51,103,255:0.246094;62,52,105,255:0.25;62,53,107,255:0.253906;63,54,109,255:0.257813;63,54,111,255:0.261719;63,55,112,255:0.265625;64,56,114,255:0.269531;64,57,116,255:0.273438;64,58,118,255:0.277344;64,59,120,255:0.28125;64,60,121,255:0.285156;65,61,123,255:0.289063;65,62,125,255:0.292969;65,62,127,255:0.296875;65,63,128,255:0.300781;65,64,130,255:0.304688;65,65,132,255:0.308594;65,66,133,255:0.3125;65,67,135,255:0.316406;65,68,136,255:0.320313;64,70,138,255:0.324219;64,71,139,255:0.328125;64,72,141,255:0.332031;64,73,142,255:0.335938;63,74,143,255:0.339844;63,75,144,255:0.34375;63,76,146,255:0.347656;62,77,147,255:0.351563;62,79,148,255:0.355469;62,80,149,255:0.359375;61,81,149,255:0.363281;61,82,150,255:0.367188;60,83,151,255:0.371094;60,85,152,255:0.375;59,86,152,255:0.378906;59,87,153,255:0.382813;59,88,154,255:0.386719;58,89,154,255:0.390625;58,91,155,255:0.394531;58,92,155,255:0.398438;57,93,156,255:0.402344;57,94,156,255:0.40625;56,95,156,255:0.410156;56,97,157,255:0.414063;56,98,157,255:0.417969;56,99,157,255:0.421875;55,100,158,255:0.425781;55,101,158,255:0.429688;55,102,158,255:0.433594;55,104,159,255:0.4375;54,105,159,255:0.441406;54,106,159,255:0.445313;54,107,159,255:0.449219;54,108,160,255:0.453125;54,109,160,255:0.457031;54,111,160,255:0.460938;54,112,160,255:0.464844;54,113,160,255:0.46875;53,114,161,255:0.472656;53,115,161,255:0.476563;53,116,161,255:0.480469;53,117,161,255:0.484375;53,118,162,255:0.488281;53,120,162,255:0.492188;53,121,162,255:0.496094;53,122,162,255:0.5;53,123,163,255:0.503906;53,124,163,255:0.507813;53,125,163,255:0.511719;53,126,164,255:0.515625;52,127,164,255:0.519531;52,128,164,255:0.523438;52,130,164,255:0.527344;52,131,165,255:0.53125;52,132,165,255:0.535156;52,133,165,255:0.539063;52,134,165,255:0.542969;52,135,166,255:0.546875;52,136,166,255:0.550781;52,137,166,255:0.554688;52,139,166,255:0.558594;52,140,167,255:0.5625;52,141,167,255:0.566406;52,142,167,255:0.570313;52,143,167,255:0.574219;52,144,168,255:0.578125;52,145,168,255:0.582031;52,146,168,255:0.585938;52,147,168,255:0.589844;52,149,169,255:0.59375;52,150,169,255:0.597656;52,151,169,255:0.601563;52,152,169,255:0.605469;52,153,170,255:0.609375;52,154,170,255:0.613281;53,155,170,255:0.617188;53,156,170,255:0.621094;53,158,170,255:0.625;53,159,171,255:0.628906;53,160,171,255:0.632813;53,161,171,255:0.636719;54,162,171,255:0.640625;54,163,171,255:0.644531;54,164,171,255:0.648438;55,165,172,255:0.652344;55,166,172,255:0.65625;55,168,172,255:0.660156;56,169,172,255:0.664063;56,170,172,255:0.667969;57,171,172,255:0.671875;57,172,172,255:0.675781;58,173,172,255:0.679688;58,174,173,255:0.683594;59,175,173,255:0.6875;60,177,173,255:0.691406;60,178,173,255:0.695313;61,179,173,255:0.699219;62,180,173,255:0.703125;63,181,173,255:0.707031;63,182,173,255:0.710938;64,183,173,255:0.714844;65,184,173,255:0.71875;66,185,173,255:0.722656;67,186,173,255:0.726563;68,188,173,255:0.730469;69,189,173,255:0.734375;70,190,173,255:0.738281;71,191,173,255:0.742188;72,192,173,255:0.746094;73,193,173,255:0.75;75,194,173,255:0.753906;76,195,173,255:0.757813;77,196,173,255:0.761719;79,197,173,255:0.765625;80,198,173,255:0.769531;82,199,173,255:0.773438;83,201,173,255:0.777344;85,202,173,255:0.78125;87,203,173,255:0.785156;89,204,173,255:0.789063;91,205,173,255:0.792969;94,205,173,255:0.796875;96,206,172,255:0.800781;98,207,172,255:0.804688;101,208,173,255:0.808594;104,209,173,255:0.8125;106,210,173,255:0.816406;109,211,173,255:0.820313;112,212,173,255:0.824219;115,212,173,255:0.828125;118,213,174,255:0.832031;121,214,174,255:0.835938;124,214,175,255:0.839844;127,215,175,255:0.84375;130,216,176,255:0.847656;133,217,177,255:0.851563;136,217,177,255:0.855469;139,218,178,255:0.859375;142,219,179,255:0.863281;145,219,180,255:0.867188;148,220,181,255:0.871094;150,221,181,255:0.875;153,221,182,255:0.878906;156,222,183,255:0.882813;158,223,184,255:0.886719;161,223,185,255:0.890625;164,224,187,255:0.894531;166,225,188,255:0.898438;169,225,189,255:0.902344;171,226,190,255:0.90625;174,227,192,255:0.910156;176,228,193,255:0.914063;178,228,194,255:0.917969;181,229,196,255:0.921875;183,230,197,255:0.925781;185,230,199,255:0.929688;187,231,200,255:0.933594;190,232,202,255:0.9375;192,233,204,255:0.941406;194,233,205,255:0.945313;196,234,207,255:0.949219;198,235,209,255:0.953125;200,236,210,255:0.957031;202,237,212,255:0.960938;204,237,214,255:0.964844;206,238,215,255:0.96875;208,239,217,255:0.972656;210,240,219,255:0.976563;212,241,220,255:0.980469;214,241,222,255:0.984375;216,242,224,255:0.988281;218,243,225,255"/>
+    </colorramp>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style fontSizeUnit="Point" isExpression="0" fontLetterSpacing="0" textOrientation="horizontal" fontWeight="50" fontItalic="0" useSubstitutions="0" fontFamily="Bahnschrift Condensed" textOpacity="1" allowHtml="0" fieldName="StreamOrde" fontStrikeout="0" multilineHeight="1" fontWordSpacing="0" namedStyle="Condensed" textColor="255,255,255,255" legendString="Aa" capitalization="0" blendMode="0" previewBkgrdColor="255,255,255,255" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSize="8" fontKerning="1" fontUnderline="0">
+        <families/>
+        <text-buffer bufferSize="0" bufferDraw="0" bufferJoinStyle="128" bufferBlendMode="0" bufferNoFill="0" bufferOpacity="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSizeUnits="MM" bufferColor="255,255,255,255"/>
+        <text-mask maskJoinStyle="128" maskType="0" maskOpacity="1" maskedSymbolLayers="" maskSizeUnits="MM" maskSize="0.20000000000000001" maskEnabled="1" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+        <background shapeBorderWidthUnit="Point" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeOffsetX="0" shapeRotation="0" shapeSVGFile="" shapeSizeUnit="Point" shapeBlendMode="0" shapeBorderWidth="0" shapeOpacity="1" shapeSizeX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="Point" shapeSizeType="0" shapeBorderColor="128,128,128,255" shapeType="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeOffsetUnit="Point" shapeRadiiX="0" shapeRadiiY="0" shapeFillColor="255,255,255,255" shapeOffsetY="0" shapeSizeY="0">
+          <symbol type="marker" name="markerSymbol" clip_to_extent="1" force_rhr="0" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" name="name" value=""/>
+                <Option name="properties"/>
+                <Option type="QString" name="type" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer locked="0" class="SimpleMarker" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" name="angle" value="0"/>
+                <Option type="QString" name="cap_style" value="square"/>
+                <Option type="QString" name="color" value="232,113,141,255"/>
+                <Option type="QString" name="horizontal_anchor_point" value="1"/>
+                <Option type="QString" name="joinstyle" value="bevel"/>
+                <Option type="QString" name="name" value="circle"/>
+                <Option type="QString" name="offset" value="0,0"/>
+                <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+                <Option type="QString" name="offset_unit" value="MM"/>
+                <Option type="QString" name="outline_color" value="35,35,35,255"/>
+                <Option type="QString" name="outline_style" value="solid"/>
+                <Option type="QString" name="outline_width" value="0"/>
+                <Option type="QString" name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+                <Option type="QString" name="outline_width_unit" value="MM"/>
+                <Option type="QString" name="scale_method" value="diameter"/>
+                <Option type="QString" name="size" value="2"/>
+                <Option type="QString" name="size_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+                <Option type="QString" name="size_unit" value="MM"/>
+                <Option type="QString" name="vertical_anchor_point" value="1"/>
+              </Option>
+              <prop k="angle" v="0"/>
+              <prop k="cap_style" v="square"/>
+              <prop k="color" v="232,113,141,255"/>
+              <prop k="horizontal_anchor_point" v="1"/>
+              <prop k="joinstyle" v="bevel"/>
+              <prop k="name" v="circle"/>
+              <prop k="offset" v="0,0"/>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="outline_color" v="35,35,35,255"/>
+              <prop k="outline_style" v="solid"/>
+              <prop k="outline_width" v="0"/>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="outline_width_unit" v="MM"/>
+              <prop k="scale_method" v="diameter"/>
+              <prop k="size" v="2"/>
+              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="size_unit" v="MM"/>
+              <prop k="vertical_anchor_point" v="1"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" name="name" value=""/>
+                  <Option name="properties"/>
+                  <Option type="QString" name="type" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+          <symbol type="fill" name="fillSymbol" clip_to_extent="1" force_rhr="0" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" name="name" value=""/>
+                <Option name="properties"/>
+                <Option type="QString" name="type" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer locked="0" class="SimpleFill" pass="0" enabled="1">
+              <Option type="Map">
+                <Option type="QString" name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+                <Option type="QString" name="color" value="255,255,255,255"/>
+                <Option type="QString" name="joinstyle" value="bevel"/>
+                <Option type="QString" name="offset" value="0,0"/>
+                <Option type="QString" name="offset_map_unit_scale" value="3x:0,0,0,0,0,0"/>
+                <Option type="QString" name="offset_unit" value="MM"/>
+                <Option type="QString" name="outline_color" value="128,128,128,255"/>
+                <Option type="QString" name="outline_style" value="no"/>
+                <Option type="QString" name="outline_width" value="0"/>
+                <Option type="QString" name="outline_width_unit" value="Point"/>
+                <Option type="QString" name="style" value="solid"/>
+              </Option>
+              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="color" v="255,255,255,255"/>
+              <prop k="joinstyle" v="bevel"/>
+              <prop k="offset" v="0,0"/>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="outline_color" v="128,128,128,255"/>
+              <prop k="outline_style" v="no"/>
+              <prop k="outline_width" v="0"/>
+              <prop k="outline_width_unit" v="Point"/>
+              <prop k="style" v="solid"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" name="name" value=""/>
+                  <Option name="properties"/>
+                  <Option type="QString" name="type" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowUnder="0" shadowOffsetAngle="135" shadowRadius="1.5" shadowDraw="1" shadowRadiusUnit="Point" shadowBlendMode="6" shadowOpacity="1" shadowOffsetDist="1" shadowColor="0,0,0,255" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowOffsetUnit="Point" shadowOffsetGlobal="1"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+        </dd_properties>
+        <substitutions/>
+      </text-style>
+      <text-format leftDirectionSymbol="&lt;" autoWrapLength="0" plussign="0" wrapChar="" decimals="3" placeDirectionSymbol="0" addDirectionSymbol="0" rightDirectionSymbol=">" multilineAlign="3" reverseDirectionSymbol="0" useMaxLineLengthForAutoWrap="1" formatNumbers="0"/>
+      <placement quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" dist="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="25" fitInPolygonOnly="0" placement="0" rotationAngle="0" lineAnchorPercent="0.5" xOffset="0" distMapUnitScale="3x:0,0,0,0,0,0" maxCurvedCharAngleOut="-25" preserveRotation="1" lineAnchorType="0" geometryGenerator="" yOffset="0" priority="5" overrunDistanceUnit="MM" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" centroidInside="0" repeatDistance="0" polygonPlacementFlags="2" centroidWhole="0" lineAnchorClipping="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" distUnits="MM" repeatDistanceUnits="MM" geometryGeneratorEnabled="0" layerType="PolygonGeometry" placementFlags="10" offsetUnits="MM" overrunDistance="0"/>
+      <rendering unplacedVisibility="0" obstacleFactor="1" mergeLines="0" scaleVisibility="0" scaleMin="0" upsidedownLabels="0" displayAll="0" obstacleType="1" minFeatureSize="0" drawLabels="1" maxNumLabels="2000" labelPerPart="0" scaleMax="0" fontMaxPixelSize="10000" limitNumLabels="0" fontMinPixelSize="3" fontLimitPixelSize="0" zIndex="0" obstacle="1"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option type="QString" name="name" value=""/>
+          <Option name="properties"/>
+          <Option type="QString" name="type" value="collection"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option type="QString" name="anchorPoint" value="pole_of_inaccessibility"/>
+          <Option type="int" name="blendMode" value="0"/>
+          <Option type="Map" name="ddProperties">
+            <Option type="QString" name="name" value=""/>
+            <Option name="properties"/>
+            <Option type="QString" name="type" value="collection"/>
+          </Option>
+          <Option type="bool" name="drawToAllParts" value="false"/>
+          <Option type="QString" name="enabled" value="0"/>
+          <Option type="QString" name="labelAnchorPoint" value="point_on_exterior"/>
+          <Option type="QString" name="lineSymbol" value="&lt;symbol type=&quot;line&quot; name=&quot;symbol&quot; clip_to_extent=&quot;1&quot; force_rhr=&quot;0&quot; alpha=&quot;1&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; name=&quot;name&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;type&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer locked=&quot;0&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; name=&quot;align_dash_pattern&quot; value=&quot;0&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;capstyle&quot; value=&quot;square&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;customdash&quot; value=&quot;5;2&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;customdash_unit&quot; value=&quot;MM&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;dash_pattern_offset&quot; value=&quot;0&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;draw_inside_polygon&quot; value=&quot;0&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;joinstyle&quot; value=&quot;bevel&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;line_color&quot; value=&quot;60,60,60,255&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;line_style&quot; value=&quot;solid&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;line_width&quot; value=&quot;0.3&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;line_width_unit&quot; value=&quot;MM&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;offset&quot; value=&quot;0&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;offset_unit&quot; value=&quot;MM&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;ring_filter&quot; value=&quot;0&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;trim_distance_end&quot; value=&quot;0&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;trim_distance_start&quot; value=&quot;0&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;use_custom_dash&quot; value=&quot;0&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;/Option>&lt;prop k=&quot;align_dash_pattern&quot; v=&quot;0&quot;/>&lt;prop k=&quot;capstyle&quot; v=&quot;square&quot;/>&lt;prop k=&quot;customdash&quot; v=&quot;5;2&quot;/>&lt;prop k=&quot;customdash_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;customdash_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;dash_pattern_offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;dash_pattern_offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;dash_pattern_offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;draw_inside_polygon&quot; v=&quot;0&quot;/>&lt;prop k=&quot;joinstyle&quot; v=&quot;bevel&quot;/>&lt;prop k=&quot;line_color&quot; v=&quot;60,60,60,255&quot;/>&lt;prop k=&quot;line_style&quot; v=&quot;solid&quot;/>&lt;prop k=&quot;line_width&quot; v=&quot;0.3&quot;/>&lt;prop k=&quot;line_width_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;offset&quot; v=&quot;0&quot;/>&lt;prop k=&quot;offset_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;offset_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;ring_filter&quot; v=&quot;0&quot;/>&lt;prop k=&quot;trim_distance_end&quot; v=&quot;0&quot;/>&lt;prop k=&quot;trim_distance_end_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;trim_distance_end_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;trim_distance_start&quot; v=&quot;0&quot;/>&lt;prop k=&quot;trim_distance_start_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;prop k=&quot;trim_distance_start_unit&quot; v=&quot;MM&quot;/>&lt;prop k=&quot;tweak_dash_pattern_on_corners&quot; v=&quot;0&quot;/>&lt;prop k=&quot;use_custom_dash&quot; v=&quot;0&quot;/>&lt;prop k=&quot;width_map_unit_scale&quot; v=&quot;3x:0,0,0,0,0,0&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; name=&quot;name&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; name=&quot;type&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"/>
+          <Option type="double" name="minLength" value="0"/>
+          <Option type="QString" name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0"/>
+          <Option type="QString" name="minLengthUnit" value="MM"/>
+          <Option type="double" name="offsetFromAnchor" value="0"/>
+          <Option type="QString" name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0"/>
+          <Option type="QString" name="offsetFromAnchorUnit" value="MM"/>
+          <Option type="double" name="offsetFromLabel" value="0"/>
+          <Option type="QString" name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0"/>
+          <Option type="QString" name="offsetFromLabelUnit" value="MM"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <legend type="default-vector" showLabelLegend="0"/>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>


### PR DESCRIPTION
This started out as a simple exercise to expose log files, reports and geopackages consistently across the suite of production grade tools in response to #276. I went ahead and did that for all the project types listed below (screenshots of new project trees shown). Along the way I also fixed some other minor inconsistencies (e.g. order of Inputs, Intermediates and Outputs). I tested each to make sure that the trees loaded correctly, and that the logs, reports and geopackages launched correctly.  I also fixed some lingering transparency issues in QGIS on some of our most common rasters. 

## RS Context
New BL:
![image](https://user-images.githubusercontent.com/9723905/134792870-1373f0d2-cb53-4290-9487-8c6582f769dd.png)
Added a transportation view.

## Channel Area
New BL:
![image](https://user-images.githubusercontent.com/9723905/134792909-83ab2b66-e003-450b-b790-37204f58cb23.png)

## TauDEM
New BL:
![image](https://user-images.githubusercontent.com/9723905/134792962-3e98fd67-0308-4984-8634-1b1566a50afe.png)
Note: for now TauDEM only has vectors in Input Geopackage (i.e. channel). This will likely change as we start using TauDEM to derive drainage networks.

## VBET
New BL:
![image](https://user-images.githubusercontent.com/9723905/134792833-c32078d5-bb05-4822-8304-b8dfd457da6a.png)


### Added exposing intermediate catchment wings

![image](https://user-images.githubusercontent.com/9723905/134792703-fa95b848-9f76-412f-9950-cb697491cd30.png)

## BRAT
New BL:
![image](https://user-images.githubusercontent.com/9723905/134793051-af5dbe41-6a67-4654-9aaf-dc4020a5c5ff.png)


## Confinement
New BL:
![image](https://user-images.githubusercontent.com/9723905/134793004-577b2fea-c2e1-4614-bbbe-be00d84c6caf.png)

