### PR TITLE
WebRave Project View update

### DIFF
--- a/RaveBusinessLogic/ChannelArea.xml
+++ b/RaveBusinessLogic/ChannelArea.xml
@@ -7,7 +7,7 @@
       <Node label="Project Report" xpath="Outputs/HTMLFile[@id='REPORT']" type="report" />
       <Node label="Outputs" xpath="Outputs">
         <Children collapsed="false">
-          <Node label="Channel Area (hollow)" xpath="Geopackage/Layers/Vector[@id='CHANNEL_AREA']" type="polygon" id="channel_area" symbology="ChannelArea_hollow" />
+          <Node label="Channel Area (hollow)" xpath="Geopackage/Layers/Vector[@id='CHANNEL_AREA']" type="polygon" id="channel_area_hollow" symbology="ChannelArea_hollow" />
           <Node label="Channel Area (filled)" xpath="Geopackage/Layers/Vector[@id='CHANNEL_AREA']" type="polygon" id="channel_area" symbology="ChannelArea" />
           <Node label="Outputs Geopackage (SQLite Database)" xpath="Geopackage" type="file" /> 
         </Children>
@@ -39,6 +39,7 @@
     <View name="Channel Area" id="DEFAULT">
       <Layers>
         <Layer id="channel_area" />
+        <Layer id="channel_area_hollow" />
       </Layers>
     </View>
   </Views>


### PR DESCRIPTION
added a separate id for the channel_area_hollow to differentiate the two layers to be used in the default project view