### PR TITLE
Queuing up some Display Order Tests

### DIFF
--- a/RaveBusinessLogic/RSContext.xml
+++ b/RaveBusinessLogic/RSContext.xml
@@ -108,7 +108,7 @@
         </Children>
       </Node>
       <Node label="Hillshade">
-        <Children collapsed="false">
+        <Children collapsed="true">
           <Node xpathlabel="Name" xpath="Raster[@id='HILLSHADE']" type="raster" symbology="hillshade" id="hs" />
         </Children>
       </Node>

--- a/RaveBusinessLogic/TauDEM.xml
+++ b/RaveBusinessLogic/TauDEM.xml
@@ -44,10 +44,14 @@
                         <Node label="Channel Area" xpath="Geopackage/Layers/Vector[@id='CHANNEL_AREA']" type="polygon"  symbology="ChannelArea" id="channel_area" />
                         <Node label="Channel Line Input" xpath="Geopackage/Layers/Vector[@id='CHANNEL_LINES']" type="line" symbology="channel_line_network" id="channel_line" />
                         <Node label="DEM" xpath="Raster[@id='DEM']" type="raster" symbology="dem" transparency="40" id="dem" />
-                        <Node label="DEM Hillshade" xpath="Raster[@id='HILLSHADE']" type="raster" symbology="hillshade" id="hillshade" />
                         <Node label="Inputs Geopackage (SQLite Database)" xpath="Geopackage" type="file" /> 
                     </Children>
                 </Node>
+                <Node label="Hillshade">
+                    <Children collapsed="true">
+                      <Node xpathlabel="Name" xpath="Inputs/Raster[@id='HILLSHADE']" type="raster" symbology="hillshade" id="hillshade" />
+                    </Children>
+                  </Node>
                 <Node label="Log File" xpath="LogFile" type="file" />
             </Children>
         </Node>

--- a/RaveBusinessLogic/VBET.xml
+++ b/RaveBusinessLogic/VBET.xml
@@ -7,7 +7,6 @@
       <Node label="Project Report" xpath="Outputs/HTMLFile" type="report" />
       <Node label="Outputs" xpath="Outputs">
         <Children collapsed="true">
-          <Node label="Likelihood of being Valley Bottom" xpath="Raster[@id='VBET_EVIDENCE']" type="raster" symbology="vbetLikelihood" transparency="40" id="likevbet" />
           <!-- These are the names from pre https://github.com/Riverscapes/riverscapes-tools/issues/427 fixes -->
           <Node label="Valley Bottom Extent (Hollow)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet68_hollow" id="vbet_extent_hollow" />               
           <Node label="Valley Bottom Extent (Filled)" xpath="Geopackage/Layers/Vector[@id='VBET_68']" type="polygon" symbology="vbet68_filled" transparency="40" id="vbet_extent_filled" />              
@@ -21,6 +20,7 @@
               <Node label="Estimated Inactive Floodplain" xpath="Geopackage/Layers/Vector[@id='INACTIVE_FLOODPLAIN']" type="polygon" symbology="vbet_inactive_floodplain" id="vbet_inactive_floodplain"/>      
             </Children>
           </Node>
+          <Node label="Likelihood of being Valley Bottom" xpath="Raster[@id='VBET_EVIDENCE']" type="raster" symbology="vbetLikelihood" transparency="40" id="likevbet" />
           <Node label="Outputs Geopackage (SQLite Database)" xpath="Geopackage" type="file" />
         </Children>
       </Node>

--- a/RaveBusinessLogic/VBET.xml
+++ b/RaveBusinessLogic/VBET.xml
@@ -57,9 +57,13 @@
           <Children collapsed="true">
             <Node label="Channel Area Polygons" xpath="Geopackage/Layers/Vector[@id='CHANNEL_AREA_POLYGONS']" type="polygon" id="channel_area_polygons" symbology="ChannelArea" />
             <Node label="Digital Elevation Model" xpath="Raster[@id='DEM']" type="raster" symbology="dem" transparency="40" id="dem" />
-            <Node label="DEM Hillshade" xpath="Raster[@id='HILLSHADE']" type="raster" symbology="hillshade" id="hillshade" />
             <Node label="Inputs Geopackage (SQLite Database)" xpath="Geopackage" type="file" />
           </Children>     
+        </Node>
+        <Node label="Hillshade">
+          <Children collapsed="true">
+            <Node xpathlabel="Name" xpath="Inputs/Raster[@id='HILLSHADE']" type="raster" symbology="hillshade" id="hillshade" />
+          </Children>
         </Node>
         <Node label="Log File" xpath="LogFile" type="file" />
       </Children>


### PR DESCRIPTION
This is some testing for #19 and #58. This does not fix #19 but it does get us ready. If we like these changes we will need to do same for BRAT, pyBRAT, RVD, pyRCAT, etc.

@MattReimer please make sure my suggested changes don't mess up what you've gotten working so nicely in WebRAVE. 

@shelbysawyer may be curious about this one FYI.

Watch the video to see how the old stuff was working in QRAVE and ArcRAVE as well as what is suggested here.
[![Video Link https://youtu.be/Z_2NnjmdUf4](http://img.youtube.com/vi/Z_2NnjmdUf4/0.jpg)](http://www.youtube.com/watch?v=Z_2NnjmdUf4 "")

This does NOT FIX our basic problems of display order, but assuming we go with the suggestion of:

> ### Suggestion 1: layer sorting priority
> Right now in QGIS the intent is that the layers are supposed to be added to the map in the same order that they exist in the tree. Obviously this is different than ArcRave which treats layers like a stack that always adds to the top
> 
> Where we could go with this is a set of sorting priorities when deciding where in a group to place layers.
> 
> Sorting priorities when comparing two layers:
> - If they are different types prioritize as follows [points, lines, polygons, rasters]
> - If they are the same type stack the newer layer on top
> With this schema rasters are always below vectors, polys are always below lines etc. but the newest layer added is always at the top. This is kind of what webrave does (albeit a lot more simply)
> 
> This doesn't address sorting between groups. Because groups are arbitrarily hierarchical I don't think there's a strategy here.
> 
> ### Suggestion 2: Fix the group ordering
> This is pretty non-controversial. Groups should get added in the same order as they exist in the business logic. This is what's supposed to happen and it's not so that's a bug.
