### PR TITLE
Created Perennial Network WebRAVE Symbology for BRAT Outputs

### DIFF
--- a/Symbology/web/BRAT/limitation_peren.json
+++ b/Symbology/web/BRAT/limitation_peren.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(0, 5%, 84%)", "Dam Building Possible"],
+    ["hsl(100, 100%, 23%)", "Naturally Vegetation Limited"],
+    ["hsl(52, 100%, 45%)", "Anthropogenically Limited"],
+    ["hsl(0, 100%, 48%)", "Slope Limited"], 
+    [ "hsl(314, 100%, 73%)","Potential Reservoir or Landuse"], 
+    [ "hsl(194, 100%, 50%)","Stream Power Limited" ], 
+    ["hsl(0, 0%, 61%)", "TBD"]
+  ],
+  "layerStyles": [
+    {
+      "id": "Unsuitable or Limited Opportunities",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "BRAT_results-4wzuaw",
+      "layout": {},
+      "paint": {
+          "line-color": [
+              "match",
+              ["get", "Limitation"],
+              ["Dam Building Possible"],
+              "hsl(0, 5%, 84%)",
+              ["Naturally Vegetation Limited"],
+              "hsl(100, 100%, 23%)",
+              ["Anthropogenically Limited"],
+              "hsl(52, 100%, 45%)",
+              ["Slope Limited"],
+              "hsl(0, 100%, 48%)",
+              ["Potential Reservoir or Landuse"],
+              "hsl(314, 100%, 73%)",
+              ["Stream Power Limited"],
+              "hsl(194, 100%, 50%)",
+              ["...TBD..."],
+              "hsl(0, 0%, 61%)",
+              "#000000"
+          ],
+          "line-opacity": [
+            "match",
+            ["get", "ReachCode"],
+            [33400, 46003, 46007],
+            0,
+            1
+        ]
+      }
+  }
+  ]
+}

--- a/Symbology/web/BRAT/opportunity_peren.json
+++ b/Symbology/web/BRAT/opportunity_peren.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(120, 100%, 33%)", "Easiest - Low-Hanging Fruit"],
+    ["hsl(194, 100%, 50%)", "Straight Forward - Quick Return"],
+    ["hsl(194, 100%, 73%)","Strategic - Long-Term Investment"],
+    ["hsl(0, 0%, 73%","Other"]
+  ],
+  "layerStyles": [
+    {
+      "id": "Restoration or Conservation Opportunities",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "BRAT_results-4wzuaw",
+      "layout": {},
+      "paint": {
+          "line-color": [
+              "match",
+              ["get", "Opportunity"],
+              ["Easiest - Low-Hanging Fruit"],
+              "hsl(120, 100%, 33%)",
+              ["Straight Forward - Quick Return"],
+              "hsl(194, 100%, 50%)",
+              ["Strategic - Long-Term Investment"],
+              "hsl(194, 100%, 73%)",
+              ["NA"],
+              "hsl(0, 0%, 73%)",
+              "#000000"
+          ],
+          "line-opacity": [
+            "match",
+            ["get", "ReachCode"],
+            [33400, 46003, 46007,33600],
+            0,
+            1
+        ]
+      }
+  }
+  ]
+}

--- a/Symbology/web/BRAT/risk_peren.json
+++ b/Symbology/web/BRAT/risk_peren.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(0, 100%, 45%)", "Considerable Risk"],
+    ["hsl(40, 100%, 50%)", "Some Risk"],
+    ["hsl(194, 100%, 50%)","Minor Risk"],
+    ["hsl(0, 0%, 88%)","Negligible Risk"]
+  ],
+  "layerStyles": [
+    {
+        "id": "Risk of Undesireable Dams",
+        "type": "line",
+        "source": "composite",
+        "source-layer": "BRAT_results-4wzuaw",
+        "layout": {},
+        "paint": {
+            "line-color": [
+                "match",
+                ["get", "Risk"],
+                ["Negligible Risk"],
+                "hsl(0, 0%, 88%)",
+                ["Minor Risk"],
+                "hsl(194, 100%, 50%)",
+                ["Some Risk"],
+                "hsl(40, 100%, 50%)",
+                ["Considerable Risk"],
+                "hsl(0, 100%, 45%)",
+                "hsl(178, 4%, 100%)"
+              ],
+              "line-opacity": [
+                  "match",
+                  ["get", "ReachCode"],
+                  [33400, 46003, 46007],
+                  0,
+                  1
+              ]
+        }
+    }
+  ]
+}

--- a/Symbology/web/Shared/Existing_Capacity_Peren.json
+++ b/Symbology/web/Shared/Existing_Capacity_Peren.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(0, 100%, 48%)", "None: 0 dams"],
+    ["hsl(40, 100%, 50%)", "Rare: 0-1 dams/km (0-2 dams/mi)"],
+    ["hsl(60, 100%, 48%)","Occasional:  1-5 dams/km (2-8 dams/mi)"],
+    ["hsl(100, 99%, 45%)","Frequent: 5-15 dams/km (8-24 dams/mi)"],
+    ["hsl(216, 100%, 45%)","Pervasive: 15-40 dams/km (24-64 dams/mi)"]
+  ],
+  "layerStyles": [
+    {
+      "id": "Existing Dam Capacity ",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "oCC_EX-bmdfb2",
+      "layout": {},
+      "paint": {
+          "line-width": 1.25,
+          "line-color": [
+              "step",
+              ["get", "oCC_EX"],
+              "hsl(0, 100%, 48%)",
+              0.000001,
+              "hsl(40, 100%, 50%)",
+              1,
+              "hsl(40, 100%, 50%)",
+              1.000001,
+              "hsl(60, 100%, 48%)",
+              5,
+              "hsl(60, 100%, 48%)",
+              5.000001,
+              "hsl(100, 99%, 45%)",
+              15,
+              "hsl(100, 99%, 45%)",
+              15.000001,
+              "hsl(216, 100%, 45%)",
+              31,
+              "hsl(216, 100%, 45%)"
+          ],
+          "line-opacity": [
+            "match",
+            ["get", "ReachCode"],
+            [33400, 46003, 46007],
+            0,
+            1
+        ]
+      }
+  }
+  ]
+}

--- a/Symbology/web/Shared/Existing_Dam_Size_Peren.json
+++ b/Symbology/web/Shared/Existing_Dam_Size_Peren.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(0, 100%, 48%)", "No Dams"],
+    ["hsl(40, 100%, 50%)", "Single Dam"],
+    ["hsl(60, 100%, 48%)","Small Complex (1-3 dams)"],
+    ["hsl(100, 100%, 45%)","Medium Complex (3-5 dams)"],
+    ["hsl(216, 100%, 45%)","Large Complex (>5 dams)"]
+  ],
+  "layerStyles": [
+    {
+      "id": "Existing Dam Size",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "BRAT_results-4wzuaw",
+      "layout": {},
+      "paint": {
+          "line-color": [
+              "step",
+              ["get", "mCC_EX_CT"],
+              "hsl(0, 100%, 48%)",
+              0.000001,
+              "hsl(40, 100%, 50%)",
+              1,
+              "hsl(40, 100%, 50%)",
+              1.000001,
+              "hsl(60, 100%, 48%)",
+              3,
+              "hsl(60, 100%, 48%)",
+              3.000001,
+              "hsl(100, 100%, 45%)",
+              5,
+              "hsl(100, 100%, 45%)",
+              5.000001,
+              "hsl(216, 100%, 45%)",
+              10.81,
+              "hsl(216, 100%, 45%)"
+          ],
+          "line-opacity": [
+              "match",
+              ["get", "ReachCode"],
+              [33400, 46003, 46007],
+              0,
+              1
+          ]
+      }
+  }
+]
+}

--- a/Symbology/web/Shared/Historic_Capacity_Peren.json
+++ b/Symbology/web/Shared/Historic_Capacity_Peren.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(0, 100%, 48%)", "None: 0 dams"],
+    ["hsl(40, 100%, 50%)", "Rare: 0-1 dams/km (0-2 dams/mi)"],
+    ["hsl(60, 100%, 48%)","Occasional:  1-5 dams/km (2-8 dams/mi)"],
+    ["hsl(100, 99%, 45%)","Frequent: 5-15 dams/km (8-24 dams/mi)"],
+    ["hsl(216, 100%, 45%)","Pervasive: 15-40 dams/km (24-64 dams/mi)"]
+  ],
+  "layerStyles": [
+    {
+      "id": "Historic Dam Capacity ",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "oCC_EX-bmdfb2",
+      "layout": {},
+      "paint": {
+          "line-width": 1.25,
+          "line-color": [
+              "step",
+              ["get", "oCC_HPE"],
+              "hsl(0, 100%, 48%)",
+              0.000001,
+              "hsl(40, 100%, 50%)",
+              1,
+              "hsl(40, 100%, 50%)",
+              1.000001,
+              "hsl(60, 100%, 48%)",
+              5,
+              "hsl(60, 100%, 48%)",
+              5.000001,
+              "hsl(100, 99%, 45%)",
+              15,
+              "hsl(100, 99%, 45%)",
+              15.000001,
+              "hsl(216, 100%, 45%)",
+              31,
+              "hsl(216, 100%, 45%)"
+          ],
+          "line-opacity": [
+            "match",
+            ["get", "ReachCode"],
+            [33400, 46003, 46007,33600],
+            0,
+            1
+        ]
+      }
+  }
+  ]
+}

--- a/Symbology/web/Shared/Historic_Dam_Size_Peren.json
+++ b/Symbology/web/Shared/Historic_Dam_Size_Peren.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(0, 100%, 48%)", "No Dams"],
+    ["hsl(40, 100%, 50%)", "Single Dam"],
+    ["hsl(60, 100%, 48%)","Small Complex (1-3 dams)"],
+    ["hsl(100, 100%, 45%)","Medium Complex (3-5 dams)"],
+    ["hsl(216, 100%, 45%)","Large Complex (>5 dams)"]
+  ],
+  "layerStyles": [
+    {
+      "id": "Historic Dam Size",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "BRAT_results-4wzuaw",
+      "layout": {},
+      "paint": {
+          "line-color": [
+              "step",
+              ["get", "mCC_HPE_CT"],
+              "hsl(0, 100%, 48%)",
+              0.000001,
+              "hsl(40, 100%, 50%)",
+              1,
+              "hsl(40, 100%, 50%)",
+              1.000001,
+              "hsl(60, 100%, 48%)",
+              3,
+              "hsl(60, 100%, 48%)",
+              3.000001,
+              "hsl(100, 100%, 45%)",
+              5,
+              "hsl(100, 100%, 45%)",
+              5.000001,
+              "hsl(216, 100%, 45%)",
+              10.81,
+              "hsl(216, 100%, 45%)"
+          ],
+          "line-opacity": [
+              "match",
+              ["get", "ReachCode"],
+              [33400, 46003, 46007,33600],
+              0,
+              1
+          ]
+      }
+  }
+]
+}


### PR DESCRIPTION
Created symbology to display Perennial Network for 7 BRAT outputs based on discussion in #373. Accomplished by making non-perennial reach codes transparent. 