### PR TITLE
fixed typo in HAND label

### DIFF
--- a/RaveBusinessLogic/RSContext.xml
+++ b/RaveBusinessLogic/RSContext.xml
@@ -104,7 +104,7 @@
           <Node label="Slope Analysis" xpath="Raster[@id='SLOPE']" type="raster" symbology="slope" transparency="40" />
           <Node xpathlabel="Name" xpath="Raster[@id='FA']" type="raster" symbology="flow_accumulation" transparency="40" />
           <Node label="Drainage Area" xpath="Raster[@id='DA']" type="raster" symbology="drainage_area" transparency="40" />
-          <Node label="Detrended DEM (HAND - Height Above Nearest Drainge)" xpath="Raster[@id='HAND']" type="raster" symbology="hand" transparency="40" />
+          <Node label="Detrended DEM (HAND - Height Above Nearest Drainage)" xpath="Raster[@id='HAND']" type="raster" symbology="hand" transparency="40" />
         </Children>
       </Node>
       <Node label="Hillshade">


### PR DESCRIPTION
I just noticed from viewing in webRAVE that 'a' was missing in 'Drainge' so I fixed it quick.