### PR TITLE
GUT outputs symbolized for WebRAVE

### DIFF
--- a/Symbology/web/GUT/out_Tier1_FlowUnit.json
+++ b/Symbology/web/GUT/out_Tier1_FlowUnit.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(216, 100%, 45%)", "Submerged"],
+    ["hsl(100, 100%, 23%)", "Emergent"],
+    ["hsl(19, 34%, 40%)", "High"]
+  ],
+  "layerStyles": [
+    {
+        "id": "out-tier1-flowunit-7pafkk copy",
+        "type": "line",
+        "source": "composite",
+        "source-layer": "out_Tier1_FlowUnit-7pafkk",
+        "layout": {},
+        "paint": {
+            "line-color": [
+                "match",
+                ["get", "FlowUnit"],
+                ["Submerged"],
+                "hsl(216, 100%, 45%)",
+                ["Emergent"],
+                "hsl(100, 100%, 23%)",
+                ["High"],
+                "hsl(19, 34%, 40%)"
+            ]
+        }
+    }
+  ]
+}

--- a/Symbology/web/GUT/out_Tier1_ValleyUnit.json
+++ b/Symbology/web/GUT/out_Tier1_ValleyUnit.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(195, 78%, 77%)", "In-Channel"],
+    ["hsl(120, 29%, 57%)", "Out-of-Channel"]
+  ],
+  "layerStyles": [
+    {
+        "id": "out-tier1-flowunit-7pafkk",
+        "type": "fill",
+        "source": "composite",
+        "source-layer": "out_Tier1_FlowUnit-7pafkk",
+        "layout": {},
+        "paint": {
+            "fill-color": [
+                "match",
+                ["get", "ValleyUnit"],
+                ["In-Channel"],
+                "hsl(195, 78%, 77%)",
+                ["Out-of-Channel"],
+                "hsl(120, 29%, 57%)"
+            ]
+        }
+    }
+  ]
+}

--- a/Symbology/web/GUT/out_Tier2_UnitForm.json
+++ b/Symbology/web/GUT/out_Tier2_UnitForm.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(213, 100%, 33%)", "Bowl"],
+    ["hsl(196, 100%, 45%)", "Bowl Transition"],
+    ["hsl(194, 100%, 73%)", "Trough"],
+    ["hsl(60, 100%, 45%)", "Plane"],
+    ["hsl(0, 100%, 75%)", "Mound Transition"],
+    ["hsl(40, 100%, 45%)", "Saddle"],
+    ["hsl(0, 100%, 33%)", "Mound"],
+    ["hsl(240, 100%, 0%)", "Wall"]
+  ],
+  "layerStyles": [
+    {
+        "id": "tier2-6ve9tm",
+        "type": "fill",
+        "source": "composite",
+        "source-layer": "Tier2-6ve9tm",
+        "layout": {},
+        "paint": {
+            "fill-color": [
+                "match",
+                ["get", "UnitForm"],
+                ["Bowl"],
+                "hsl(213, 100%, 33%)",
+                ["Bowl Transition"],
+                "hsl(196, 100%, 45%)",
+                ["Trough"],
+                "hsl(194, 100%, 73%)",
+                ["Plane"],
+                "hsl(60, 100%, 45%)",
+                ["Mound Transition"],
+                "hsl(0, 100%, 75%)",
+                ["Saddle"],
+                "hsl(40, 100%, 45%)",
+                ["Mound"],
+                "hsl(0, 100%, 33%)"
+            ]
+          }
+    }
+  ]        
+}

--- a/Symbology/web/GUT/out_Tier2_UnitForm_Discrete.json
+++ b/Symbology/web/GUT/out_Tier2_UnitForm_Discrete.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(213, 100%, 33%)", "Bowl"],
+    ["hsl(194, 100%, 73%)", "Trough"],
+    ["hsl(60, 100%, 45%)", "Plane"],
+    ["hsl(40, 100%, 50%)", "Saddle"],
+    ["hsl(0, 100%, 33%)", "Mound"],
+    ["hsl(240, 100%, 0%)", "Wall"]
+  ],
+  "layerStyles": [
+    {
+        "id": "tier2-discrete-c0dnpo",
+        "type": "fill",
+        "source": "composite",
+        "source-layer": "Tier2_discrete-c0dnpo",
+        "layout": {},
+        "paint": {
+            "fill-color": [
+                "match",
+                ["get", "UnitForm"],
+                ["Bowl"],
+                "hsl(213, 100%, 33%)",
+                ["Trough"],
+                "hsl(194, 100%, 73%)",
+                ["Plane"],
+                "hsl(60, 100%, 45%)",
+                ["Saddle"],
+                "hsl(40, 100%, 50%)",
+                ["Mound"],
+                "hsl(0, 100%, 33%)",
+                ["Wall"],
+                "hsl(240, 100%, 0%)"
+            ]
+        }
+    }
+  ]
+}

--- a/Symbology/web/GUT/out_Tier2_UnitShape.json
+++ b/Symbology/web/GUT/out_Tier2_UnitShape.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(202, 66%, 43%)", "Concavity"],
+    ["hsl(38, 96%, 54%)", "Convexity"],
+    ["hsl(57, 93%, 53%)", "Planar"]
+  ],
+  "layerStyles": [
+    {
+        "id": "tier2-6ve9tm",
+        "type": "fill",
+        "source": "composite",
+        "source-layer": "Tier2-6ve9tm",
+        "layout": {},
+        "paint": {
+            "fill-color": [
+                "match",
+                ["get", "UnitShape"],
+                ["Concavity"],
+                "hsl(202, 66%, 43%)",
+                ["Convexity"],
+                "hsl(38, 96%, 54%)",
+                ["Planar"],
+                "hsl(57, 93%, 53%)"
+            ]
+        }
+    }
+  ]
+}

--- a/Symbology/web/GUT/out_Tier3_GeomorphicUnit.json
+++ b/Symbology/web/GUT/out_Tier3_GeomorphicUnit.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(240, 100%, 0%)", "Bank"],
+    ["hsl(213, 100%, 33%)", "Pool"],
+    ["hsl(214, 100%, 50%)", "Pond"],
+    ["hsl(213, 100%, 73%)", "Pocket Pool"],
+    ["hsl(186, 100%, 50%)", "Chute"],
+    ["hsl(160, 51%, 60%)", "Rapid"],
+    ["hsl(158, 34%, 40%)", "Cascade"],
+    ["hsl(60, 100%, 45%)", "Glide-Run"],
+    ["hsl(40, 100%, 45%)", "Riffle"],
+    ["hsl(19, 42%, 73%)", "Step"],
+    ["hsl(19, 34%, 40%)", "Mid Channel Bar"],
+    ["hsl(0, 100%, 33%)", "Margin Attached Bar"],
+    ["hsl(0, 100%, 23%)", "Barface"],
+    ["hsl(0, 0%, 80%)", "Transition"]
+  ],
+  "layerStyles": [
+    {
+      "id": "tier3-ck4bw8",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "Tier3-ck4bw8",
+      "layout": {},
+      "paint": {
+          "fill-color": [
+              "match",
+              ["get", "GU"],
+              ["Bank"],
+              "hsl(240, 100%, 0%)",
+              ["Pool"],
+              "hsl(213, 100%, 33%)",
+              ["Pond"],
+              "hsl(214, 100%, 50%)",
+              ["Pocket Pool"],
+              "hsl(213, 100%, 73%)",
+              ["Chute"],
+              "hsl(186, 100%, 50%)",
+              ["Rapid"],
+              "hsl(160, 51%, 60%)",
+              ["Cascade"],
+              "hsl(158, 34%, 40%)",
+              ["Glide-Run"],
+              "hsl(60, 100%, 45%)",
+              ["Riffle"],
+              "hsl(40, 100%, 45%)",
+              ["Step"],
+              "hsl(19, 42%, 73%)",
+              ["Mid Channel Bar"],
+              "hsl(19, 34%, 40%)",
+              ["Margin Attached Bar"],
+              "hsl(0, 100%, 33%)",
+              ["Barface"],
+              "hsl(0, 100%, 23%)",
+              ["Transition"],
+              "hsl(0, 0%, 80%)"
+          ]
+      }
+  }
+  ]
+}

--- a/Symbology/web/GUT/out_Tier3_Orientation.json
+++ b/Symbology/web/GUT/out_Tier3_Orientation.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(60, 94%, 69%)", "Diagonal"],
+    ["hsl(200, 67%, 47%)", "Longitudinal"],
+    ["hsl(359, 87%, 49%)", "Transverse"]
+  ],
+  "layerStyles": [
+    {
+      "id": "tier3-orient-440k40",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "Tier3_Orient-440k40",
+      "layout": {},
+      "paint": {
+          "fill-color": [
+              "match",
+              ["get", "OrientCat"],
+              ["Diagonal"],
+              "hsl(60, 94%, 69%)",
+              ["Longitudinal"],
+              "hsl(200, 67%, 47%)",
+              ["Transverse"],
+              "hsl(359, 87%, 49%)"
+          ]
+      }
+  }
+  ]
+}

--- a/Symbology/web/GUT/out_Tier3_Position.json
+++ b/Symbology/web/GUT/out_Tier3_Position.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(200, 67%, 47%)", "Channel Spanning"],
+    ["hsl(77, 46%, 69%)", "Margin Attached"],
+    ["hsl(36, 97%, 63%)", "Margin Detached"],
+    ["hsl(0, 83%, 50%)", "Mid Channel"]
+  ],
+  "layerStyles": [
+    {
+      "id": "tier3-orient-440k40",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "Tier3_Orient-440k40",
+      "layout": {},
+      "paint": {
+          "fill-color": [
+              "match",
+              ["get", "Position"],
+              ["Channel Spanning"],
+              "hsl(200, 67%, 47%)",
+              ["Margin Attached"],
+              "hsl(77, 46%, 69%)",
+              ["Margin Detached"],
+              "hsl(36, 97%, 63%)",
+              ["Mid Channel"],
+              "hsl(0, 83%, 50%)"
+          ]
+      }
+  }
+  ]
+}

--- a/Symbology/web/GUT/out_Tier3_SubGU.json
+++ b/Symbology/web/GUT/out_Tier3_SubGU.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(240, 100%, 0%)", "Bank"],
+    ["hsl(0, 0%, 41%)", "Cutbank"],
+    ["hsl(213, 100%, 33%)", "Pool"],
+    ["hsl(220, 100%, 23%)", "Beaver Pond"],
+    ["hsl(194, 100%, 73%)", "Plunge Pool"],
+    ["hsl(60, 100%, 45%)", "Run"],
+    ["hsl(60, 100%, 73%)", "Glide"],
+    ["hsl(40, 100%, 45%)", "Riffle"],
+    ["hsl(40, 51%, 60%)", "Bench"],
+    ["hsl(0, 100%, 23%)", "Barface"],
+    ["hsl(20, 100%, 23%)", "Counter Point Bar"],
+    ["hsl(0, 34%, 40%)", "Diagonal Bar"],
+    ["hsl(19, 34%, 40%)", "Longitudinal Bar"],
+    ["hsl(0, 100%, 33%)", "Lateral Bar"],
+    ["hsl(0, 51%, 60%)", "Lobate Bar"],
+    ["hsl(0, 42%, 73%)", "Point Bar"],
+    ["hsl(0, 0%, 88%)", "Other"]
+  ],
+  "layerStyles": [
+    {
+      "id": "tier3-subgu-c3h25k",
+      "type": "fill",
+      "source": "composite",
+      "source-layer": "Tier3_subGU-c3h25k",
+      "layout": {},
+      "paint": {
+          "fill-color": [
+              "match",
+              ["get", "SubGU"],
+              ["Bank"],
+              "hsl(240, 100%, 0%)",
+              ["Cutbank"],
+              "hsl(0, 0%, 41%)",
+              ["Pool"],
+              "hsl(213, 100%, 33%)",
+              ["Beaver Pond"],
+              "hsl(220, 100%, 23%)",
+              ["Plunge Pool"],
+              "hsl(194, 100%, 73%)",
+              ["Run"],
+              "hsl(60, 100%, 45%)",
+              ["Glide"],
+              "hsl(60, 100%, 73%)",
+              ["Riffle"],
+              "hsl(40, 100%, 45%)",
+              ["Bench"],
+              "hsl(40, 51%, 60%)",
+              ["Barface"],
+              "hsl(0, 100%, 23%)",
+              ["Counter Point Bar"],
+              "hsl(20, 100%, 23%)",
+              ["Diagonal Bar"],
+              "hsl(0, 34%, 40%)",
+              ["Longitudinal Bar"],
+              "hsl(19, 34%, 40%)",
+              ["Lateral Bar"],
+              "hsl(0, 100%, 33%)",
+              ["Lobate Bar"],
+              "hsl(0, 51%, 60%)",
+              ["Point Bar"],
+              "hsl(0, 42%, 73%)",
+              ["Other"],
+              "hsl(0, 0%, 88%)"
+          ]
+      }
+  }
+  ]
+}


### PR DESCRIPTION
GUT output symbology for webRAVE