### PR TITLE
Inundation crests_type symbology fix

### DIFF
--- a/Symbology/web/Inundation/crests_type.json
+++ b/Symbology/web/Inundation/crests_type.json
@@ -6,23 +6,22 @@
   ],
   "layerStyles": [
     {
-        "id": "cresttype-1sei67",
-        "type": "line",
-        "source": "composite",
-        "source-layer": "cresttype-1sei67",
-        "layout": {"visibility": "none"},
-        "paint": {
-            "line-color": [
-                "match",
-                ["get", "crest_type"],
-                ["active"],
-                "hsl(100, 100%, 50%)",
-                ["inactive"],
-                "hsl(0, 100%, 50%)",
-                "#000000"
-            ],
-            "line-width": 3
-        }
-    }
+      "id": "cresttype-1sei67",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "cresttype-1sei67",
+      "paint": {
+          "line-color": [
+              "match",
+              ["get", "crest_type"],
+              ["active"],
+              "hsl(100, 100%, 50%)",
+              ["inactive"],
+              "hsl(0, 100%, 50%)",
+              "#000000"
+          ],
+          "line-width": 3
+      }
+  }
   ]
 }


### PR DESCRIPTION
The symbology for crests_type was not displaying in webRave. There was a minor error in the file that I fixed so it should work now