### PR TITLE
Removing Realization parameters

### DIFF
--- a/Projects/XSD/V2/RiverscapesProject.xsd
+++ b/Projects/XSD/V2/RiverscapesProject.xsd
@@ -75,7 +75,6 @@
       <xs:element type="xs:string" name="Citation" minOccurs="0" maxOccurs="1" />
 
       <xs:element type="MetaDataType" name="MetaData" minOccurs="0" maxOccurs="1" />
-      <xs:element type="ParametersType" name="Parameters" minOccurs="0" maxOccurs="1" />
 
       <xs:element name="Logs" maxOccurs="1" minOccurs="0">
         <xs:complexType>
@@ -153,12 +152,6 @@
         <xs:attribute type="MetaKeyValueType" name="type" use="optional" />
       </xs:extension>
     </xs:simpleContent>
-  </xs:complexType>
-
-  <xs:complexType name="ParametersType">
-    <xs:sequence>
-      <xs:element type="ParamType" name="Param" maxOccurs="unbounded" minOccurs="0" />
-    </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="MetricType">
@@ -330,7 +323,7 @@
 
 
   <xs:complexType name="QAQCEventsType">
-    <xs:choice maxOccurs="unbounded">
+    <xs:choice maxOccurs="unbounded" minOccurs="0">
       <xs:element type="QAQCEventType" name="QAQCEvent" />
     </xs:choice>
   </xs:complexType>

--- a/Projects/XSD/V2/examples/Empty.xml
+++ b/Projects/XSD/V2/examples/Empty.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../RiverscapesProject.xsd">
+
+  <Name>VBET for HUC 16050301</Name>
+  <ProjectType>VBET</ProjectType>
+
+  <Warehouse id="badfe8c1-0342-4876-8fac-b2eb5493a90f" apiUrl="https://12312312.amazon.ca/api/prod"/>
+  <Summary></Summary>
+  <Description></Description>
+  <Citation></Citation>
+
+  <MetaData>
+    <Meta name="ModelVersion">0.5.0</Meta>
+  </MetaData>
+
+  <QAQCEvents>
+  </QAQCEvents>
+
+  <CommonDatasets>
+  </CommonDatasets>
+
+
+  <!-- CHANGE: here is our ProjectBounds for geospatial searching and map display -->
+  <ProjectBounds>
+    <Centroid>
+      <Lat>43.03677585761058</Lat>
+      <Lng>-105.46875</Lng>
+    </Centroid>
+    <BoundingBox>
+      <MinLat>38.58252615935333</MinLat>
+      <MinLng>-115.13671875</MinLng>
+      <MaxLat>46.6795944656402</MaxLat>
+      <MaxLng>-96.0205078125</MaxLng>
+    </BoundingBox>
+    <Path>some_file_name.geojson</Path>
+  </ProjectBounds>
+
+  <Realizations>
+    <Realization id="REALIZATION1" dateCreated="2021-10-02T16:48:48.772237" productVersion="0.1.2">
+      <Name></Name>
+    </Realization>
+  </Realizations>
+</Project>

--- a/Projects/XSD/V2/examples/Hydro.xml
+++ b/Projects/XSD/V2/examples/Hydro.xml
@@ -57,10 +57,6 @@
           <Meta name="run_type">NA</Meta>
           <Meta name="qa_status">pass</Meta>
         </MetaData>
-        <Parameters>
-          <Param name="surveyed_discharge">TRUE</Param>
-          <!--We need to discuss the other parameters that should go here-->
-        </Parameters>
         
         <Inputs>
           <CommonDatasetRef ref="DEM1"/>


### PR DESCRIPTION
`<Parameters>` was a good idea in theory but it's doing the same work as `<Metadata>` and it's only ever used by legacy Hydro projects so we should remove it from the spec. 

Existing Parameters tags can be migrated safely and automatically into Metadata