### PR TITLE
Fix uncolored logging

### DIFF
--- a/python/packages/rsxml/rsxml/logging/logger.py
+++ b/python/packages/rsxml/rsxml/logging/logger.py
@@ -108,7 +108,7 @@ class _LoggerSingleton:
                 msg = f'[{severity}] [{method}] {message}'
 
             # Print to stdout
-            if not NO_UI or colored is None:
+            if not NO_UI and colored is not None:
                 if severity == 'debug':
                     msg = colored(msg, 'cyan')
                 if severity == 'warning':


### PR DESCRIPTION
Running the example without termcolor returns the error `TypeError: 'NoneType' object is not callable`.