### PR TITLE
Adding condition, condition_igo & FPAccess symbology

### DIFF
--- a/Symbology/web/RCAT/FPAccess.json
+++ b/Symbology/web/RCAT/FPAccess.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["#e81014", "0.0-0.2"],
+    ["#e600a9", "0.2-0.4"], 
+    ["#8400a8", "0.4-0.6"], 
+    ["#4c0073", "0.6-0.8"], 
+    ["#002673", "0.8-1.0"]
+  ],
+  "layerStyles": [
+    {
+    "id": "fpaccess-bo5cqs",
+    "type": "line",
+    "source": "composite",
+    "source-layer": "FPAccess-bo5cqs",
+    "layout": {},
+    "paint": {
+        "line-color": [
+            "interpolate",
+            ["linear"],
+            ["get", "FloodplainAccess"],
+            0,
+            "#e81014",
+            0.2,
+            "#e81014",
+            0.20001,
+            "#e600a9",
+            0.4,
+            "#e600a9",
+            0.400001,
+            "#8400a8",
+            0.6,
+            "#8400a8",
+            0.600001,
+            "#4c0073",
+            0.8,
+            "#4c0073",
+            0.800001,
+            "#002673"
+        ]
+      }
+    }    
+  ]
+}

--- a/Symbology/web/RCAT/condition_igo_v2.json
+++ b/Symbology/web/RCAT/condition_igo_v2.json
@@ -2,9 +2,9 @@
   "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
   "legend": [
     ["#ed2024", "Very Poor <0.20"],
-    ["#fba919", "Poor 0.20-0.40"]
-    ["#f7f278", "Moderate 0.40-0.60"]
-    ["#b0d136", "Good 0.65-0.85"]
+    ["#fba919", "Poor 0.20-0.40"],
+    ["#f7f278", "Moderate 0.40-0.60"],
+    ["#b0d136", "Good 0.65-0.85"],
     ["#5abf92", "Intact >0.85"]
   ],
   "layerStyles": [
@@ -58,5 +58,5 @@
               "#5abf92"
           ]
       }
-  }
+  }]
 }

--- a/Symbology/web/RCAT/condition_igo_v2.json
+++ b/Symbology/web/RCAT/condition_igo_v2.json
@@ -1,61 +1,62 @@
 {
   "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
   "legend": [
-    ["hsl(0, 100%, 48%)", "Very Poor < 0.20"],
-    ["hsl(40, 100%, 50%)", "Poor 0.2 - 0.4"],
-    ["hsl(55, 100%, 50%)", "Moderate 0.4 - 0.65"],
-    ["hsl(80, 100%, 45%)", "Good 0.65 - 0.85"],
-    ["hsl(100, 100%, 33%)", "Intact > 0.85"]
+    ["#ed2024", "Very Poor <0.20"],
+    ["#fba919", "Poor 0.20-0.40"]
+    ["#f7f278", "Moderate 0.40-0.60"]
+    ["#b0d136", "Good 0.65-0.85"]
+    ["#5abf92", "Intact >0.85"]
   ],
   "layerStyles": [
     {
-        "id": "igo-6dm17v",
-        "type": "circle",
-        "source": "composite",
-        "source-layer": "IGO-6dm17v",
-        "layout": {},
-        "paint": {
-            "circle-color": [
-                "interpolate",
-                ["linear"],
-                ["get", "Condition"],
-                0.00,
-                "hsl(0, 100%, 48%)",
-                0.2,
-                "hsl(0, 100%, 48%)",
-                0.20001,
-                "hsl(40, 100%, 50%)",
-                0.4,
-                "hsl(40, 100%, 50%)",
-                0.40001,
-                "hsl(55, 100%, 50%)",
-                0.65,
-                "hsl(55, 100%, 50%)",
-                0.650001,
-                "hsl(80, 100%, 45%)",
-                0.85,
-                "hsl(80, 100%, 45%)",
-                0.850001,
-                "hsl(100, 100%, 33%)",
-                1.00,
-                "hsl(100, 100%, 33%)"
-            ],
-            "circle-radius": [
-                "interpolate",
-                ["linear"],
-                ["zoom"],
-                10,
-                1,
-                11,
-                2,
-                13.55,
-                3,
-                15,
-                4,
-                22,
-                5
-            ]
-        }
-    }
-  ]
+      "id": "condition-igo-v2-bgocbh",
+      "type": "circle",
+      "source": "composite",
+      "source-layer": "condition_igo_v2-bgocbh",
+      "layout": {},
+      "paint": {
+        "circle-radius": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          10,
+          1,
+          11,
+          2,
+          13.55,
+          3,
+          15,
+          4,
+          22,
+          5
+        ],
+          "circle-color": [
+              "interpolate",
+              ["linear"],
+              ["get", "Condition"],
+              0.0,
+              "#ed2024",
+              0.2,
+              "#ed2024",
+              0.200001,
+              "#fba919",
+              0.4,
+              "#fba919",
+              0.400001,
+              "#f7f278",
+              0.65,
+              "#f7f278",
+              0.650001,
+              "#b0d136",
+              0.85,
+              "#b0d136",
+              0.850001,
+              "#5abf92"
+          ]
+      }
+  }
 }

--- a/Symbology/web/RCAT/condition_igo_v2.json
+++ b/Symbology/web/RCAT/condition_igo_v2.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(0, 100%, 48%)", "Very Poor < 0.20"],
+    ["hsl(40, 100%, 50%)", "Poor 0.2 - 0.4"],
+    ["hsl(55, 100%, 50%)", "Moderate 0.4 - 0.65"],
+    ["hsl(80, 100%, 45%)", "Good 0.65 - 0.85"],
+    ["hsl(100, 100%, 33%)", "Intact > 0.85"]
+  ],
+  "layerStyles": [
+    {
+        "id": "igo-6dm17v",
+        "type": "circle",
+        "source": "composite",
+        "source-layer": "IGO-6dm17v",
+        "layout": {},
+        "paint": {
+            "circle-color": [
+                "interpolate",
+                ["linear"],
+                ["get", "Condition"],
+                0.00,
+                "hsl(0, 100%, 48%)",
+                0.2,
+                "hsl(0, 100%, 48%)",
+                0.20001,
+                "hsl(40, 100%, 50%)",
+                0.4,
+                "hsl(40, 100%, 50%)",
+                0.40001,
+                "hsl(55, 100%, 50%)",
+                0.65,
+                "hsl(55, 100%, 50%)",
+                0.650001,
+                "hsl(80, 100%, 45%)",
+                0.85,
+                "hsl(80, 100%, 45%)",
+                0.850001,
+                "hsl(100, 100%, 33%)",
+                1.00,
+                "hsl(100, 100%, 33%)"
+            ],
+            "circle-radius": [
+                "interpolate",
+                ["linear"],
+                ["zoom"],
+                10,
+                1,
+                11,
+                2,
+                13.55,
+                3,
+                15,
+                4,
+                22,
+                5
+            ]
+        }
+    }
+  ]
+}

--- a/Symbology/web/RCAT/condition_v2.json
+++ b/Symbology/web/RCAT/condition_v2.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
+  "legend": [
+    ["hsl(0, 100%, 48%)", "Very Poor < 0.20"],
+    ["hsl(40, 100%, 50%)", "Poor 0.20 - 0.40"],
+    ["hsl(55, 100%, 50%)", "Moderate 0.40 - 0.65"],
+    ["hsl(80, 100%, 45%)", "Good 0.65 - 0.85"],
+    ["hsl(100, 100%, 33%)", "Intact > 0.85"]
+  ],
+  "layerStyles": [
+    {
+      "id": "condition-9o8khy",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "condition-9o8khy",
+      "layout": {},
+      "paint": {
+          "line-color": [
+              "interpolate",
+              ["linear"],
+              ["get", "Condition"],
+              0.0000,
+              "hsl(0, 100%, 48%)",
+              0.2000,
+              "hsl(0, 100%, 48%)",
+              0.20001,
+              "hsl(40, 100%, 50%)",
+              0.4,
+              "hsl(40, 100%, 50%)",
+              0.40001,
+              "hsl(55, 100%, 50%)",
+              0.65,
+              "hsl(55, 100%, 50%)",
+              0.650001,
+              "hsl(80, 100%, 45%)",
+              0.85,
+              "hsl(80, 100%, 45%)",
+              0.850001,
+              "hsl(100, 100%, 33%)",
+              1.000,
+              "hsl(100, 100%, 33%)"
+          ]
+      }
+  }
+  ]
+}

--- a/Symbology/web/RCAT/condition_v2.json
+++ b/Symbology/web/RCAT/condition_v2.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
   "legend": [
-    ["hsl(0, 100%, 48%)", "Very Poor < 0.20"],
+    ["#ff0303", "Very Poor < 0.20"],
     ["hsl(40, 100%, 50%)", "Poor 0.20 - 0.40"],
     ["hsl(55, 100%, 50%)", "Moderate 0.40 - 0.65"],
     ["hsl(80, 100%, 45%)", "Good 0.65 - 0.85"],
@@ -9,36 +9,34 @@
   ],
   "layerStyles": [
     {
-      "id": "condition-9o8khy",
+      "id": "condition-v2-7guh4l",
       "type": "line",
       "source": "composite",
-      "source-layer": "condition-9o8khy",
+      "source-layer": "condition_v2-7guh4l",
       "layout": {},
       "paint": {
           "line-color": [
               "interpolate",
               ["linear"],
               ["get", "Condition"],
-              0.0000,
-              "hsl(0, 100%, 48%)",
-              0.2000,
-              "hsl(0, 100%, 48%)",
+              0.00,
+              "#ff0303",
+              0.2,
+              "#ff0303",
               0.20001,
-              "hsl(40, 100%, 50%)",
+              "#fba919",
               0.4,
-              "hsl(40, 100%, 50%)",
+              "#fba919",
               0.40001,
-              "hsl(55, 100%, 50%)",
+              "#f7f278",
               0.65,
-              "hsl(55, 100%, 50%)",
+              "#f7f278",
               0.650001,
-              "hsl(80, 100%, 45%)",
+              "#b0d136",
               0.85,
-              "hsl(80, 100%, 45%)",
+              "#b0d136",
               0.850001,
-              "hsl(100, 100%, 33%)",
-              1.000,
-              "hsl(100, 100%, 33%)"
+              "#5abf92"
           ]
       }
   }


### PR DESCRIPTION
Adding condition, condition_igo & FPAccess symbology. Will add field for Conversion Type (reach & igo) next week per https://github.com/Riverscapes/RiverscapesXML/issues/650. I figured it was most critical to get the current layers symbolizing correctly in WebRave for Alden ASAP. 