### PR TITLE
fixing WebRAVE legend colors

### DIFF
--- a/Symbology/web/RCAT/condition_v2.json
+++ b/Symbology/web/RCAT/condition_v2.json
@@ -2,10 +2,10 @@
   "$schema": "https://xml.riverscapes.xyz/Symbology/web/vector.schema.json",
   "legend": [
     ["#ff0303", "Very Poor < 0.20"],
-    ["hsl(40, 100%, 50%)", "Poor 0.20 - 0.40"],
-    ["hsl(55, 100%, 50%)", "Moderate 0.40 - 0.65"],
-    ["hsl(80, 100%, 45%)", "Good 0.65 - 0.85"],
-    ["hsl(100, 100%, 33%)", "Intact > 0.85"]
+    ["#fba919", "Poor 0.20 - 0.40"],
+    ["#f7f278", "Moderate 0.40 - 0.65"],
+    ["#b0d136", "Good 0.65 - 0.85"],
+    ["#5abf92", "Intact > 0.85"]
   ],
   "layerStyles": [
     {


### PR DESCRIPTION
I didn't update the colors on the legend correctly to match new symbology. Should be fixed now. 