### PR TITLE
QRAVE ConditionType Symboloby

### DIFF
--- a/RaveBusinessLogic/V2/RCAT.xml
+++ b/RaveBusinessLogic/V2/RCAT.xml
@@ -25,6 +25,7 @@
                             <Node label="Riparian Vegetation Departure" xpath="Outputs/Geopackage/Layers/Vector[@lyrName='vwIgos']" type="point" symbology="rvd_igo" id="rvd_igo"/>
                             <Node label="Land Use Intensity" xpath="Outputs/Geopackage/Layers/Vector[@lyrName='vwIgos']" type="point" symbology="iPC_LU_igo" id="LUI_igo" />
                             <Node label="Floodplain Accessibility" xpath="Outputs/Geopackage/Layers/Vector[@lyrName='vwIgos']" type="point" symbology="FPAccess_igo" id="fpaccess_igo"/>
+                            <Node label="Riparian Vegetation Conversion Type" xpath="Outputs/Geopackage/Layers/Vector[@lyrName='vwIgos']" type="point" symbology="Veg_conversion_igo" id="Veg_conversion_igo"/>
                         </Children>
                     </Node>
                     <Node label="Reaches">
@@ -32,6 +33,7 @@
                             <Node label="Riparian Vegetation Departure" xpath="Outputs/Geopackage/Layers/Vector[@lyrName='vwReaches']" type="line" symbology="rvd" id="rvd"/>
                             <Node label="Land Use Intensity" xpath="Outputs/Geopackage/Layers/Vector[@lyrName='vwReaches']" type="line" symbology="iPC_LU" id="LUI"/>
                             <Node label="Floodplain Accessibility" xpath="Outputs/Geopackage/Layers/Vector[@lyrName='vwReaches']" type="line" symbology="FPAccess" id="fpaccess"/>
+                            <Node label="Riparian Vegetation Conversion Type" xpath="Outputs/Geopackage/Layers/Vector[@lyrName='vwReaches']" type="line" symbology="Veg_conversion" id="Veg_conversion"/>
                         </Children>
                     </Node>
                     <Node label="Rasters">

--- a/RaveBusinessLogic/V2/RCAT.xml
+++ b/RaveBusinessLogic/V2/RCAT.xml
@@ -76,6 +76,7 @@
                     <Node label="Digital Elevation Model">
                         <Children collapsed="true">
                             <Node label="Pit-filled DEM" xpath="Raster[@id='PITFILL']" type="raster" symbology="dem" transparency="40" id="dem" />
+                            <Node label="Hillshade" xpath="Raster[@id='HILLSHADE']" type="raster" symbology="hillshade" transparency="40" id="hillshade" />
                         </Children>
                     </Node>
                 </Children>
@@ -86,7 +87,7 @@
      <View name="Riparian Condition" id="RCAT_Condition">
       <Description>This view is the riparian condition ouptut from RCAT</Description>
       <Layers>
-        <Layer id="dem"/>
+        <Layer id="hillshade"/>
         <Layer id="vb"/>
         <Layer id="rcat_condition"/>
       </Layers>
@@ -94,7 +95,7 @@
      <View name="DGOs and IGOs" id="DGO_IGO">
       <Description>This view shows the IGOs and DGOs</Description>
       <Layers>
-       <Layer id="dem"/>
+       <Layer id="hillshade"/>
        <Layer id="dgo"/>
        <Layer id="igo"/>
       </Layers>
@@ -102,7 +103,7 @@
      <View name="RVD" id="rvd_rip">
       <Description>This view shows the riparian vegetation departure (RVD) output overlayed on the existing riprarian vegetation raster</Description>
       <Layers>
-       <Layer id="dem"/>
+       <Layer id="hillshade"/>
        <Layer id="evt_rip"/>
        <Layer id="rvd"/>
       </Layers>

--- a/RaveBusinessLogic/V2/RCAT.xml
+++ b/RaveBusinessLogic/V2/RCAT.xml
@@ -42,7 +42,7 @@
                             <Node label="Historic Riparian" xpath="Intermediates/Raster[@id='HISTRIPARIAN']" type="raster" symbology="Rip_Veg" transparency="40"/>
                             <Node label="Existing Vegetated" xpath="Intermediates/Raster[@id='EXVEGETATED']" type="raster" symbology="Veg" transparency="40"/>
                             <Node label="Historic Vegetated" xpath="Intermediates/Raster[@id='HISTVEGETATED']" type="raster" symbology="Veg" transparency="40"/>
-                            <Node label="Conversion" xpath="Intermediates/Raster[@id='CONVERSION']" type="raster" symbology="Veg_Conversion" transparency="40"/>
+                            <Node label="Conversion" xpath="Intermediates/Raster[@id='CONVERSION']" type="raster" symbology="Veg_Conversion_raster" transparency="40"/>
                             <Node label="Floodplain Accessibility" xpath="Intermediates/Raster[@id='FPACCESS']" type="raster" symbology="FPAccess_Raster" transparency="40"/>
                         </Children>
                     </Node>

--- a/Symbology/qgis/RCAT/Veg_Conversion.qml
+++ b/Symbology/qgis/RCAT/Veg_Conversion.qml
@@ -274,7 +274,7 @@
             <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
             <Option name="draw_inside_polygon" value="0" type="QString"/>
             <Option name="joinstyle" value="bevel" type="QString"/>
-            <Option name="line_color" value="31,47,231,255" type="QString"/>
+            <Option name="line_color" value="247,214,167,255" type="QString"/>
             <Option name="line_style" value="solid" type="QString"/>
             <Option name="line_width" value="0.26" type="QString"/>
             <Option name="line_width_unit" value="MM" type="QString"/>
@@ -321,7 +321,7 @@
             <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
             <Option name="draw_inside_polygon" value="0" type="QString"/>
             <Option name="joinstyle" value="bevel" type="QString"/>
-            <Option name="line_color" value="147,246,170,255" type="QString"/>
+            <Option name="line_color" value="242,209,228,255" type="QString"/>
             <Option name="line_style" value="solid" type="QString"/>
             <Option name="line_width" value="0.26" type="QString"/>
             <Option name="line_width_unit" value="MM" type="QString"/>
@@ -697,7 +697,7 @@
             <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
             <Option name="draw_inside_polygon" value="0" type="QString"/>
             <Option name="joinstyle" value="bevel" type="QString"/>
-            <Option name="line_color" value="31,218,231,255" type="QString"/>
+            <Option name="line_color" value="215,235,242,255" type="QString"/>
             <Option name="line_style" value="solid" type="QString"/>
             <Option name="line_width" value="0.26" type="QString"/>
             <Option name="line_width_unit" value="MM" type="QString"/>

--- a/Symbology/qgis/RCAT/Veg_Conversion.qml
+++ b/Symbology/qgis/RCAT/Veg_Conversion.qml
@@ -1,18 +1,18 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories" minScale="0" version="3.28.1-Firenze" maxScale="0">
+<qgis simplifyDrawingTol="1" labelsEnabled="0" styleCategories="AllStyleCategories" version="3.30.2-'s-Hertogenbosch" simplifyLocal="1" simplifyDrawingHints="1" symbologyReferenceScale="-1" hasScaleBasedVisibilityFlag="0" maxScale="0" minScale="0" simplifyAlgorithm="0" simplifyMaxScale="1" readOnly="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <temporal enabled="0" mode="0" fetchMode="0">
+  <temporal durationField="" mode="0" limitMode="0" endField="" startExpression="" durationUnit="min" fixedDuration="0" startField="" endExpression="" enabled="0" accumulate="0">
     <fixedRange>
       <start></start>
       <end></end>
     </fixedRange>
   </temporal>
-  <elevation enabled="0" band="1" zscale="1" symbology="Line" zoffset="0">
+  <elevation zoffset="0" clamping="Terrain" extrusion="0" binding="Centroid" zscale="1" respectLayerSymbol="1" type="IndividualFeatures" symbology="Line" showMarkerSymbolInSurfacePlots="0" extrusionEnabled="0">
     <data-defined-properties>
       <Option type="Map">
         <Option name="name" value="" type="QString"/>
@@ -21,7 +21,7 @@
       </Option>
     </data-defined-properties>
     <profileLineSymbol>
-      <symbol name="" is_animated="0" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" type="line">
+      <symbol name="" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
             <Option name="name" value="" type="QString"/>
@@ -29,7 +29,7 @@
             <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" class="SimpleLine" pass="0" locked="0">
+        <layer class="SimpleLine" id="{f4ecc64a-47b2-4044-9b08-4326b75808b7}" pass="0" locked="0" enabled="1">
           <Option type="Map">
             <Option name="align_dash_pattern" value="0" type="QString"/>
             <Option name="capstyle" value="square" type="QString"/>
@@ -41,7 +41,7 @@
             <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
             <Option name="draw_inside_polygon" value="0" type="QString"/>
             <Option name="joinstyle" value="bevel" type="QString"/>
-            <Option name="line_color" value="133,182,111,255" type="QString"/>
+            <Option name="line_color" value="196,60,57,255" type="QString"/>
             <Option name="line_style" value="solid" type="QString"/>
             <Option name="line_width" value="0.6" type="QString"/>
             <Option name="line_width_unit" value="MM" type="QString"/>
@@ -70,7 +70,7 @@
       </symbol>
     </profileLineSymbol>
     <profileFillSymbol>
-      <symbol name="" is_animated="0" clip_to_extent="1" force_rhr="0" alpha="1" frame_rate="10" type="fill">
+      <symbol name="" force_rhr="0" alpha="1" clip_to_extent="1" type="fill" is_animated="0" frame_rate="10">
         <data_defined_properties>
           <Option type="Map">
             <Option name="name" value="" type="QString"/>
@@ -78,17 +78,17 @@
             <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" class="SimpleFill" pass="0" locked="0">
+        <layer class="SimpleFill" id="{82c0d52f-6d3c-4f5e-b14c-fbbc93ff659e}" pass="0" locked="0" enabled="1">
           <Option type="Map">
             <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-            <Option name="color" value="133,182,111,255" type="QString"/>
+            <Option name="color" value="196,60,57,255" type="QString"/>
             <Option name="joinstyle" value="bevel" type="QString"/>
             <Option name="offset" value="0,0" type="QString"/>
             <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
             <Option name="offset_unit" value="MM" type="QString"/>
-            <Option name="outline_color" value="35,35,35,255" type="QString"/>
-            <Option name="outline_style" value="no" type="QString"/>
-            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_color" value="140,43,41,255" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.2" type="QString"/>
             <Option name="outline_width_unit" value="MM" type="QString"/>
             <Option name="style" value="solid" type="QString"/>
           </Option>
@@ -102,83 +102,1303 @@
         </layer>
       </symbol>
     </profileFillSymbol>
+    <profileMarkerSymbol>
+      <symbol name="" force_rhr="0" alpha="1" clip_to_extent="1" type="marker" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" id="{8625dc06-e17c-4f35-b924-e558d08547c3}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="angle" value="0" type="QString"/>
+            <Option name="cap_style" value="square" type="QString"/>
+            <Option name="color" value="196,60,57,255" type="QString"/>
+            <Option name="horizontal_anchor_point" value="1" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="name" value="diamond" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="140,43,41,255" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.2" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="scale_method" value="diameter" type="QString"/>
+            <Option name="size" value="3" type="QString"/>
+            <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="size_unit" value="MM" type="QString"/>
+            <Option name="vertical_anchor_point" value="1" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </profileMarkerSymbol>
   </elevation>
+  <renderer-v2 symbollevels="0" type="RuleRenderer" enableorderby="0" referencescale="-1" forceraster="0">
+    <rules key="{75dc028b-8625-4f2a-8134-41ce7bab962b}">
+      <rule filter="&quot;ConversionCode&quot; in (41, 42, 43, 44)" symbol="0" label="Conv. To Agriculture" key="{3a4c9d33-f0a8-46e0-8984-449c2d973754}"/>
+      <rule filter="&quot;ConversionCode&quot; in (29, 30, 31, 32)" symbol="1" label="Conifer Encroachment" key="{ddbfdb78-e322-4c14-b5c2-6dab1540f67d}"/>
+      <rule filter="&quot;ConversionCode&quot; in (21, 22, 23, 24)" symbol="2" label="Conv. To Grass/Shrubland" key="{a84a55e6-e8a1-43aa-be94-2bd1c965dd7b}"/>
+      <rule filter="&quot;ConversionCode&quot; in (33, 34, 35, 36)" symbol="3" label="Conv. To Invasive" key="{224bd769-f61b-4801-a2ca-24255e626b01}"/>
+      <rule filter="&quot;ConversionCode&quot; in (45, 46, 47, 48)" symbol="4" label="Non-Riparian Conversions" key="{97c4ec22-d7b3-404b-8e08-187f063b726f}"/>
+      <rule filter="&quot;ConversionCode&quot; in (25, 26, 27, 28)" symbol="5" label="Devegetation" key="{fff74000-5f09-4e8f-8fca-a6c1401c8925}"/>
+      <rule filter="&quot;ConversionCode&quot; in (37, 38, 39, 40)" symbol="6" label="Developement" key="{919f0df1-8e2e-45e0-8c85-9b25ad246754}"/>
+      <rule filter="&quot;ConversionCode&quot; in (49, 50, 51, 52)" symbol="7" label="Multiple Conv. Types" key="{74d61be2-95a5-4a1a-bc49-50a619bd38b3}"/>
+      <rule filter="&quot;ConversionCode&quot; = 0" symbol="8" label="Negligible to Minor Veg. Conversion" key="{71226376-9989-4e05-bf60-2466b47e70af}"/>
+      <rule filter="&quot;ConversionCode&quot; in (9, 10, 11, 12)" symbol="9" label="From Grass/Shrubland to Riparian" key="{f4ac2792-b1e7-4032-91a6-60a227011146}"/>
+      <rule filter="&quot;ConversionCode&quot; in (5, 6, 7, 8)" symbol="10" label="From Devegetated to Riparian" key="{ee66b604-3b9e-4583-b7b8-3b84d7210f9f}"/>
+      <rule filter="&quot;ConversionCode&quot; in (1, 2, 3, 4)" symbol="11" label="From Conifer to Riparian" key="{5bba7653-c1a8-45a3-b25b-0c69dcf6202a}"/>
+    </rules>
+    <symbols>
+      <symbol name="0" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" id="{1478d543-300f-48bd-8dcb-a42edf41cfa2}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="229,229,21,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="1" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" id="{1478d543-300f-48bd-8dcb-a42edf41cfa2}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="215,70,153,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="10" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" id="{7a589f15-bd76-4ea9-8bf3-6afc1d6a6aba}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="31,47,231,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="11" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" id="{653f3296-8026-43d6-93d4-604b4a7a21c2}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="147,246,170,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="2" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" id="{1478d543-300f-48bd-8dcb-a42edf41cfa2}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="54,195,242,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="3" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" id="{1478d543-300f-48bd-8dcb-a42edf41cfa2}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="137,76,158,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="4" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" id="{1478d543-300f-48bd-8dcb-a42edf41cfa2}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="249,114,11,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="5" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" id="{c5c5d67b-852a-4fda-8307-6d6a6d2e803c}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="166,116,42,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="6" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" id="{2e4ec6cd-21ab-4f2d-89d8-95ffd7f98ed2}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="237,32,36,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="7" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" id="{67c985ba-815f-449a-8732-b4c4b42684fe}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="79,79,79,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="8" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" id="{e44d3714-0aa8-4006-bf19-8a63cf7bc9ad}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="109,190,69,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="9" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" id="{1fd3bd45-eaf8-4477-9ddf-fbb45a16a860}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="31,218,231,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style forcedItalic="0" multilineHeight="1" fontWordSpacing="0" forcedBold="0" fieldName="&quot;StreamName&quot;" fontSizeMapUnitScale="3x:0,0,0,0,0,0" textOrientation="horizontal" fontUnderline="0" capitalization="0" fontKerning="1" isExpression="1" fontSize="8" allowHtml="0" textColor="0,0,0,255" useSubstitutions="0" blendMode="0" fontItalic="0" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" fontSizeUnit="Point" multilineHeightUnit="Percentage" fontWeight="16" fontFamily="Arial" namedStyle="" previewBkgrdColor="255,255,255,255" textOpacity="1">
+        <families/>
+        <text-buffer bufferDraw="0" bufferSizeUnits="Point" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferNoFill="1" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="2" bufferOpacity="1"/>
+        <text-mask maskSize="1.5" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskJoinStyle="128" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskedSymbolLayers="" maskType="0"/>
+        <background shapeRotation="0" shapeBorderWidthUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeRadiiY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeSizeX="0" shapeFillColor="255,255,255,255" shapeSizeY="0" shapeJoinStyle="64" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeBorderColor="128,128,128,255" shapeSizeUnit="MM" shapeBorderWidth="0" shapeSizeType="0" shapeOffsetY="0" shapeBlendMode="0" shapeSVGFile="" shapeOffsetX="0" shapeOffsetUnit="MM" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeDraw="0" shapeOpacity="1">
+          <symbol name="fillSymbol" force_rhr="0" alpha="1" clip_to_extent="1" type="fill" is_animated="0" frame_rate="10">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" id="" pass="0" locked="0" enabled="1">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color" value="255,255,255,255" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="128,128,128,255" type="QString"/>
+                <Option name="outline_style" value="no" type="QString"/>
+                <Option name="outline_width" value="0" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="style" value="solid" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowRadiusUnit="MM" shadowOffsetUnit="MM" shadowBlendMode="6" shadowDraw="0" shadowRadiusAlphaOnly="0" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowOffsetGlobal="1" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </dd_properties>
+        <substitutions/>
+      </text-style>
+      <text-format rightDirectionSymbol=">" formatNumbers="0" autoWrapLength="0" addDirectionSymbol="0" leftDirectionSymbol="&lt;" decimals="3" useMaxLineLengthForAutoWrap="1" multilineAlign="1" placeDirectionSymbol="0" wrapChar="" plussign="0" reverseDirectionSymbol="0"/>
+      <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" centroidWhole="0" overrunDistanceUnit="MM" overrunDistance="0" maxCurvedCharAngleIn="25" lineAnchorType="0" repeatDistanceUnits="MM" layerType="UnknownGeometry" maxCurvedCharAngleOut="-25" fitInPolygonOnly="0" geometryGeneratorEnabled="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" dist="0" centroidInside="0" distUnits="Point" overlapHandling="PreventOverlap" polygonPlacementFlags="2" rotationAngle="0" placement="2" yOffset="0" lineAnchorTextPoint="FollowPlacement" offsetType="1" allowDegraded="0" placementFlags="10" lineAnchorPercent="0.5" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" lineAnchorClipping="0" repeatDistance="0" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" rotationUnit="AngleDegrees" priority="10" distMapUnitScale="3x:0,0,0,0,0,0" quadOffset="4" geometryGenerator=""/>
+      <rendering obstacle="0" fontMaxPixelSize="10000" mergeLines="0" scaleMin="0" unplacedVisibility="0" fontMinPixelSize="0" zIndex="0" limitNumLabels="0" minFeatureSize="0" upsidedownLabels="0" fontLimitPixelSize="0" labelPerPart="0" obstacleType="1" drawLabels="1" scaleVisibility="0" scaleMax="0" maxNumLabels="2000" obstacleFactor="0"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option name="name" value="" type="QString"/>
+          <Option name="properties"/>
+          <Option name="type" value="collection" type="QString"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+          <Option name="blendMode" value="0" type="int"/>
+          <Option name="ddProperties" type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+          <Option name="drawToAllParts" value="false" type="bool"/>
+          <Option name="enabled" value="0" type="QString"/>
+          <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+          <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; force_rhr=&quot;0&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; type=&quot;line&quot; is_animated=&quot;0&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{336b07b8-4677-4228-b1a5-ae53d667c9c2}&quot; pass=&quot;0&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+          <Option name="minLength" value="0" type="double"/>
+          <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="minLengthUnit" value="MM" type="QString"/>
+          <Option name="offsetFromAnchor" value="0" type="double"/>
+          <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+          <Option name="offsetFromLabel" value="0" type="double"/>
+          <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
   <customproperties>
     <Option type="Map">
-      <Option name="WMSBackgroundLayer" value="false" type="bool"/>
-      <Option name="WMSPublishDataSourceUrl" value="false" type="bool"/>
+      <Option name="dualview/previewExpressions" type="List">
+        <Option value="&quot;StreamName&quot;" type="QString"/>
+      </Option>
       <Option name="embeddedWidgets/count" value="0" type="int"/>
-      <Option name="identify/format" value="Value" type="QString"/>
+      <Option name="variableNames"/>
+      <Option name="variableValues"/>
     </Option>
   </customproperties>
-  <pipe-data-defined-properties>
-    <Option type="Map">
-      <Option name="name" value="" type="QString"/>
-      <Option name="properties"/>
-      <Option name="type" value="collection" type="QString"/>
-    </Option>
-  </pipe-data-defined-properties>
-  <pipe>
-    <provider>
-      <resampling enabled="false" zoomedOutResamplingMethod="nearestNeighbour" maxOversampling="2" zoomedInResamplingMethod="nearestNeighbour"/>
-    </provider>
-    <rasterrenderer band="1" classificationMax="1000" alphaBand="-1" nodataColor="" opacity="0.6" classificationMin="-80" type="singlebandpseudocolor">
-      <rasterTransparency/>
-      <minMaxOrigin>
-        <limits>None</limits>
-        <extent>WholeRaster</extent>
-        <statAccuracy>Estimated</statAccuracy>
-        <cumulativeCutLower>0.02</cumulativeCutLower>
-        <cumulativeCutUpper>0.98</cumulativeCutUpper>
-        <stdDevFactor>2</stdDevFactor>
-      </minMaxOrigin>
-      <rastershader>
-        <colorrampshader maximumValue="1000" classificationMode="1" clip="0" minimumValue="-80" colorRampType="DISCRETE" labelPrecision="0">
-          <colorramp name="[source]" type="gradient">
-            <Option type="Map">
-              <Option name="color1" value="166,206,227,255" type="QString"/>
-              <Option name="color2" value="177,89,40,255" type="QString"/>
-              <Option name="direction" value="ccw" type="QString"/>
-              <Option name="discrete" value="0" type="QString"/>
-              <Option name="rampType" value="gradient" type="QString"/>
-              <Option name="spec" value="rgb" type="QString"/>
-              <Option name="stops" value="0.0185185;31,120,180,255;rgb;ccw:0.0277778;178,223,138,255;rgb;ccw:0.0740741;178,178,178,255;rgb;ccw:0.0741667;51,160,44,255;rgb;ccw:0.119444;178,178,178,255;rgb;ccw:0.12037;251,154,153,255;rgb;ccw:0.12963;227,26,28,255;rgb;ccw:0.148148;253,191,111,255;rgb;ccw:0.163889;255,127,0,255;rgb;ccw:0.164815;202,178,214,255;rgb;ccw:0.165741;106,61,154,255;rgb;ccw:0.166667;255,255,153,255;rgb;ccw" type="QString"/>
-            </Option>
-          </colorramp>
-          <item label="From Conifer" value="-80" color="#a6cee3" alpha="255"/>
-          <item label="From Devegetated" value="-60" color="#1f78b4" alpha="255"/>
-          <item label="From Grass/Shrubland" value="-50" color="#b2df8a" alpha="255"/>
-          <item label="Upland Conversion" value="0" color="#b2b2b2" alpha="255"/>
-          <item label="No Change" value="0.1" color="#33a02c" alpha="255"/>
-          <item label="Upland Conversion" value="49" color="#b2b2b2" alpha="255"/>
-          <item label="Grass/Shrubland" value="50" color="#fb9a99" alpha="255"/>
-          <item label="Devegetation" value="60" color="#e31a1c" alpha="255"/>
-          <item label="Conifer" value="80" color="#fdbf6f" alpha="255"/>
-          <item label="Invasive" value="97" color="#ff7f00" alpha="255"/>
-          <item label="Development" value="98" color="#cab2d6" alpha="255"/>
-          <item label="Agriculture" value="99" color="#6a3d9a" alpha="255"/>
-          <item label="Non-Riparian Conversions " value="100" color="#ffff99" alpha="255"/>
-          <item label="Multiple Dominant" value="1000" color="#b15928" alpha="255"/>
-          <rampLegendSettings minimumLabel="" useContinuousLegend="1" maximumLabel="" direction="0" orientation="2" suffix="" prefix="">
-            <numericFormat id="basic">
-              <Option type="Map">
-                <Option name="decimal_separator" type="invalid"/>
-                <Option name="decimals" value="6" type="int"/>
-                <Option name="rounding_type" value="0" type="int"/>
-                <Option name="show_plus" value="false" type="bool"/>
-                <Option name="show_thousand_separator" value="true" type="bool"/>
-                <Option name="show_trailing_zeros" value="false" type="bool"/>
-                <Option name="thousand_separator" type="invalid"/>
-              </Option>
-            </numericFormat>
-          </rampLegendSettings>
-        </colorrampshader>
-      </rastershader>
-    </rasterrenderer>
-    <brightnesscontrast contrast="0" brightness="0" gamma="1"/>
-    <huesaturation colorizeOn="0" colorizeBlue="128" colorizeStrength="100" grayscaleMode="0" invertColors="0" colorizeRed="255" colorizeGreen="128" saturation="0"/>
-    <rasterresampler maxOversampling="2"/>
-    <resamplingStage>resamplingFilter</resamplingStage>
-  </pipe>
   <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+    <DiagramCategory enabled="0" lineSizeType="MM" sizeType="MM" spacing="5" penWidth="0" opacity="1" rotationOffset="270" diagramOrientation="Up" maxScaleDenominator="0" penAlpha="255" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" showAxis="1" backgroundAlpha="255" spacingUnit="MM" barWidth="5" scaleDependency="Area" width="15" sizeScale="3x:0,0,0,0,0,0" penColor="#000000" direction="0" labelPlacementMethod="XHeight" spacingUnitScale="3x:0,0,0,0,0,0" height="15" scaleBasedVisibility="0" minScaleDenominator="0" minimumSize="0">
+      <fontProperties description="MS Shell Dlg 2,7.8,-1,5,50,0,0,0,0,0" bold="0" italic="0" underline="0" strikethrough="0" style=""/>
+      <axisSymbol>
+        <symbol name="" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+          <layer class="SimpleLine" id="{aa1b8866-528d-41d5-aef8-0c8a53abb89f}" pass="0" locked="0" enabled="1">
+            <Option type="Map">
+              <Option name="align_dash_pattern" value="0" type="QString"/>
+              <Option name="capstyle" value="square" type="QString"/>
+              <Option name="customdash" value="5;2" type="QString"/>
+              <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="customdash_unit" value="MM" type="QString"/>
+              <Option name="dash_pattern_offset" value="0" type="QString"/>
+              <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+              <Option name="draw_inside_polygon" value="0" type="QString"/>
+              <Option name="joinstyle" value="bevel" type="QString"/>
+              <Option name="line_color" value="35,35,35,255" type="QString"/>
+              <Option name="line_style" value="solid" type="QString"/>
+              <Option name="line_width" value="0.26" type="QString"/>
+              <Option name="line_width_unit" value="MM" type="QString"/>
+              <Option name="offset" value="0" type="QString"/>
+              <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offset_unit" value="MM" type="QString"/>
+              <Option name="ring_filter" value="0" type="QString"/>
+              <Option name="trim_distance_end" value="0" type="QString"/>
+              <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+              <Option name="trim_distance_start" value="0" type="QString"/>
+              <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+              <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+              <Option name="use_custom_dash" value="0" type="QString"/>
+              <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            </Option>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </axisSymbol>
+    </DiagramCategory>
+  </SingleCategoryDiagramRenderer>
+  <DiagramLayerSettings obstacle="0" showAll="1" priority="0" zIndex="0" dist="0" placement="2" linePlacementFlags="18">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <legend showLabelLegend="0" type="default-vector"/>
+  <referencedLayers/>
+  <fieldConfiguration>
+    <field configurationFlags="None" name="ReachID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="ReachCode">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="WatershedID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="StreamName">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="NHDPlusID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="iPC_LU">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="FloodplainAccess">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="FromConifer">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="FromDevegetated">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="FromGrassShrubland">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="NoChange">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="GrassShrubland">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="Devegetation">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="Conifer">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="Invasive">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="Development">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="Agriculture">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="NonRiparian">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="ConversionID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="LevelID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="ExistingRiparianMean">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="HistoricRiparianMean">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="RiparianDeparture">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="RiparianDepartureID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="Condition">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="ConversionCode">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="ConversionType">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="Departure">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias index="0" field="ReachID" name=""/>
+    <alias index="1" field="ReachCode" name=""/>
+    <alias index="2" field="WatershedID" name=""/>
+    <alias index="3" field="StreamName" name=""/>
+    <alias index="4" field="NHDPlusID" name=""/>
+    <alias index="5" field="iPC_LU" name=""/>
+    <alias index="6" field="FloodplainAccess" name=""/>
+    <alias index="7" field="FromConifer" name=""/>
+    <alias index="8" field="FromDevegetated" name=""/>
+    <alias index="9" field="FromGrassShrubland" name=""/>
+    <alias index="10" field="NoChange" name=""/>
+    <alias index="11" field="GrassShrubland" name=""/>
+    <alias index="12" field="Devegetation" name=""/>
+    <alias index="13" field="Conifer" name=""/>
+    <alias index="14" field="Invasive" name=""/>
+    <alias index="15" field="Development" name=""/>
+    <alias index="16" field="Agriculture" name=""/>
+    <alias index="17" field="NonRiparian" name=""/>
+    <alias index="18" field="ConversionID" name=""/>
+    <alias index="19" field="LevelID" name=""/>
+    <alias index="20" field="ExistingRiparianMean" name=""/>
+    <alias index="21" field="HistoricRiparianMean" name=""/>
+    <alias index="22" field="RiparianDeparture" name=""/>
+    <alias index="23" field="RiparianDepartureID" name=""/>
+    <alias index="24" field="Condition" name=""/>
+    <alias index="25" field="ConversionCode" name=""/>
+    <alias index="26" field="ConversionType" name=""/>
+    <alias index="27" field="Departure" name=""/>
+  </aliases>
+  <splitPolicies>
+    <policy field="ReachID" policy="Duplicate"/>
+    <policy field="ReachCode" policy="Duplicate"/>
+    <policy field="WatershedID" policy="Duplicate"/>
+    <policy field="StreamName" policy="Duplicate"/>
+    <policy field="NHDPlusID" policy="Duplicate"/>
+    <policy field="iPC_LU" policy="Duplicate"/>
+    <policy field="FloodplainAccess" policy="Duplicate"/>
+    <policy field="FromConifer" policy="Duplicate"/>
+    <policy field="FromDevegetated" policy="Duplicate"/>
+    <policy field="FromGrassShrubland" policy="Duplicate"/>
+    <policy field="NoChange" policy="Duplicate"/>
+    <policy field="GrassShrubland" policy="Duplicate"/>
+    <policy field="Devegetation" policy="Duplicate"/>
+    <policy field="Conifer" policy="Duplicate"/>
+    <policy field="Invasive" policy="Duplicate"/>
+    <policy field="Development" policy="Duplicate"/>
+    <policy field="Agriculture" policy="Duplicate"/>
+    <policy field="NonRiparian" policy="Duplicate"/>
+    <policy field="ConversionID" policy="Duplicate"/>
+    <policy field="LevelID" policy="Duplicate"/>
+    <policy field="ExistingRiparianMean" policy="Duplicate"/>
+    <policy field="HistoricRiparianMean" policy="Duplicate"/>
+    <policy field="RiparianDeparture" policy="Duplicate"/>
+    <policy field="RiparianDepartureID" policy="Duplicate"/>
+    <policy field="Condition" policy="Duplicate"/>
+    <policy field="ConversionCode" policy="Duplicate"/>
+    <policy field="ConversionType" policy="Duplicate"/>
+    <policy field="Departure" policy="Duplicate"/>
+  </splitPolicies>
+  <defaults>
+    <default applyOnUpdate="0" field="ReachID" expression=""/>
+    <default applyOnUpdate="0" field="ReachCode" expression=""/>
+    <default applyOnUpdate="0" field="WatershedID" expression=""/>
+    <default applyOnUpdate="0" field="StreamName" expression=""/>
+    <default applyOnUpdate="0" field="NHDPlusID" expression=""/>
+    <default applyOnUpdate="0" field="iPC_LU" expression=""/>
+    <default applyOnUpdate="0" field="FloodplainAccess" expression=""/>
+    <default applyOnUpdate="0" field="FromConifer" expression=""/>
+    <default applyOnUpdate="0" field="FromDevegetated" expression=""/>
+    <default applyOnUpdate="0" field="FromGrassShrubland" expression=""/>
+    <default applyOnUpdate="0" field="NoChange" expression=""/>
+    <default applyOnUpdate="0" field="GrassShrubland" expression=""/>
+    <default applyOnUpdate="0" field="Devegetation" expression=""/>
+    <default applyOnUpdate="0" field="Conifer" expression=""/>
+    <default applyOnUpdate="0" field="Invasive" expression=""/>
+    <default applyOnUpdate="0" field="Development" expression=""/>
+    <default applyOnUpdate="0" field="Agriculture" expression=""/>
+    <default applyOnUpdate="0" field="NonRiparian" expression=""/>
+    <default applyOnUpdate="0" field="ConversionID" expression=""/>
+    <default applyOnUpdate="0" field="LevelID" expression=""/>
+    <default applyOnUpdate="0" field="ExistingRiparianMean" expression=""/>
+    <default applyOnUpdate="0" field="HistoricRiparianMean" expression=""/>
+    <default applyOnUpdate="0" field="RiparianDeparture" expression=""/>
+    <default applyOnUpdate="0" field="RiparianDepartureID" expression=""/>
+    <default applyOnUpdate="0" field="Condition" expression=""/>
+    <default applyOnUpdate="0" field="ConversionCode" expression=""/>
+    <default applyOnUpdate="0" field="ConversionType" expression=""/>
+    <default applyOnUpdate="0" field="Departure" expression=""/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="1" field="ReachID" notnull_strength="1" exp_strength="0" constraints="3"/>
+    <constraint unique_strength="0" field="ReachCode" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="WatershedID" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="StreamName" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="NHDPlusID" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="iPC_LU" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="FloodplainAccess" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="FromConifer" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="FromDevegetated" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="FromGrassShrubland" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="NoChange" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="GrassShrubland" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="Devegetation" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="Conifer" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="Invasive" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="Development" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="Agriculture" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="NonRiparian" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="ConversionID" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="LevelID" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="ExistingRiparianMean" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="HistoricRiparianMean" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="RiparianDeparture" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="RiparianDepartureID" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="Condition" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="ConversionCode" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="ConversionType" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="Departure" notnull_strength="0" exp_strength="0" constraints="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint field="ReachID" exp="" desc=""/>
+    <constraint field="ReachCode" exp="" desc=""/>
+    <constraint field="WatershedID" exp="" desc=""/>
+    <constraint field="StreamName" exp="" desc=""/>
+    <constraint field="NHDPlusID" exp="" desc=""/>
+    <constraint field="iPC_LU" exp="" desc=""/>
+    <constraint field="FloodplainAccess" exp="" desc=""/>
+    <constraint field="FromConifer" exp="" desc=""/>
+    <constraint field="FromDevegetated" exp="" desc=""/>
+    <constraint field="FromGrassShrubland" exp="" desc=""/>
+    <constraint field="NoChange" exp="" desc=""/>
+    <constraint field="GrassShrubland" exp="" desc=""/>
+    <constraint field="Devegetation" exp="" desc=""/>
+    <constraint field="Conifer" exp="" desc=""/>
+    <constraint field="Invasive" exp="" desc=""/>
+    <constraint field="Development" exp="" desc=""/>
+    <constraint field="Agriculture" exp="" desc=""/>
+    <constraint field="NonRiparian" exp="" desc=""/>
+    <constraint field="ConversionID" exp="" desc=""/>
+    <constraint field="LevelID" exp="" desc=""/>
+    <constraint field="ExistingRiparianMean" exp="" desc=""/>
+    <constraint field="HistoricRiparianMean" exp="" desc=""/>
+    <constraint field="RiparianDeparture" exp="" desc=""/>
+    <constraint field="RiparianDepartureID" exp="" desc=""/>
+    <constraint field="Condition" exp="" desc=""/>
+    <constraint field="ConversionCode" exp="" desc=""/>
+    <constraint field="ConversionType" exp="" desc=""/>
+    <constraint field="Departure" exp="" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="1" sortExpression="&quot;FloodplainAccess&quot;">
+    <columns>
+      <column width="-1" name="ReachID" type="field" hidden="0"/>
+      <column width="-1" name="ReachCode" type="field" hidden="0"/>
+      <column width="-1" name="WatershedID" type="field" hidden="0"/>
+      <column width="-1" name="StreamName" type="field" hidden="0"/>
+      <column width="-1" name="NHDPlusID" type="field" hidden="0"/>
+      <column width="-1" name="iPC_LU" type="field" hidden="0"/>
+      <column width="-1" name="FloodplainAccess" type="field" hidden="0"/>
+      <column width="-1" name="FromConifer" type="field" hidden="0"/>
+      <column width="-1" name="FromDevegetated" type="field" hidden="0"/>
+      <column width="-1" name="FromGrassShrubland" type="field" hidden="0"/>
+      <column width="-1" name="NoChange" type="field" hidden="0"/>
+      <column width="-1" name="GrassShrubland" type="field" hidden="0"/>
+      <column width="-1" name="Devegetation" type="field" hidden="0"/>
+      <column width="-1" name="Conifer" type="field" hidden="0"/>
+      <column width="-1" name="Invasive" type="field" hidden="0"/>
+      <column width="-1" name="Development" type="field" hidden="0"/>
+      <column width="-1" name="Agriculture" type="field" hidden="0"/>
+      <column width="-1" name="NonRiparian" type="field" hidden="0"/>
+      <column width="-1" name="ConversionID" type="field" hidden="0"/>
+      <column width="-1" name="LevelID" type="field" hidden="0"/>
+      <column width="-1" name="ExistingRiparianMean" type="field" hidden="0"/>
+      <column width="-1" name="HistoricRiparianMean" type="field" hidden="0"/>
+      <column width="-1" name="RiparianDeparture" type="field" hidden="0"/>
+      <column width="-1" name="RiparianDepartureID" type="field" hidden="0"/>
+      <column width="-1" name="Condition" type="field" hidden="0"/>
+      <column width="-1" name="ConversionCode" type="field" hidden="0"/>
+      <column width="-1" name="ConversionType" type="field" hidden="0"/>
+      <column width="-1" name="Departure" type="field" hidden="0"/>
+      <column width="-1" type="actions" hidden="1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <storedexpressions/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>generatedlayout</editorlayout>
+  <editable>
+    <field name="Agriculture" editable="1"/>
+    <field name="Condition" editable="1"/>
+    <field name="Conifer" editable="1"/>
+    <field name="ConversionCode" editable="1"/>
+    <field name="ConversionID" editable="1"/>
+    <field name="ConversionType" editable="1"/>
+    <field name="Departure" editable="1"/>
+    <field name="Devegetation" editable="1"/>
+    <field name="Development" editable="1"/>
+    <field name="ExistingRiparianMean" editable="1"/>
+    <field name="FloodplainAccess" editable="1"/>
+    <field name="FromConifer" editable="1"/>
+    <field name="FromDevegetated" editable="1"/>
+    <field name="FromGrassShrubland" editable="1"/>
+    <field name="GrassShrubland" editable="1"/>
+    <field name="HistoricRiparianMean" editable="1"/>
+    <field name="Invasive" editable="1"/>
+    <field name="LevelID" editable="1"/>
+    <field name="NHDPlusID" editable="1"/>
+    <field name="NoChange" editable="1"/>
+    <field name="NonRiparian" editable="1"/>
+    <field name="ReachCode" editable="1"/>
+    <field name="ReachID" editable="1"/>
+    <field name="RiparianDeparture" editable="1"/>
+    <field name="RiparianDepartureID" editable="1"/>
+    <field name="StreamName" editable="1"/>
+    <field name="WatershedID" editable="1"/>
+    <field name="iPC_LU" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="Agriculture" labelOnTop="0"/>
+    <field name="Condition" labelOnTop="0"/>
+    <field name="Conifer" labelOnTop="0"/>
+    <field name="ConversionCode" labelOnTop="0"/>
+    <field name="ConversionID" labelOnTop="0"/>
+    <field name="ConversionType" labelOnTop="0"/>
+    <field name="Departure" labelOnTop="0"/>
+    <field name="Devegetation" labelOnTop="0"/>
+    <field name="Development" labelOnTop="0"/>
+    <field name="ExistingRiparianMean" labelOnTop="0"/>
+    <field name="FloodplainAccess" labelOnTop="0"/>
+    <field name="FromConifer" labelOnTop="0"/>
+    <field name="FromDevegetated" labelOnTop="0"/>
+    <field name="FromGrassShrubland" labelOnTop="0"/>
+    <field name="GrassShrubland" labelOnTop="0"/>
+    <field name="HistoricRiparianMean" labelOnTop="0"/>
+    <field name="Invasive" labelOnTop="0"/>
+    <field name="LevelID" labelOnTop="0"/>
+    <field name="NHDPlusID" labelOnTop="0"/>
+    <field name="NoChange" labelOnTop="0"/>
+    <field name="NonRiparian" labelOnTop="0"/>
+    <field name="ReachCode" labelOnTop="0"/>
+    <field name="ReachID" labelOnTop="0"/>
+    <field name="RiparianDeparture" labelOnTop="0"/>
+    <field name="RiparianDepartureID" labelOnTop="0"/>
+    <field name="StreamName" labelOnTop="0"/>
+    <field name="WatershedID" labelOnTop="0"/>
+    <field name="iPC_LU" labelOnTop="0"/>
+  </labelOnTop>
+  <reuseLastValue>
+    <field reuseLastValue="0" name="Agriculture"/>
+    <field reuseLastValue="0" name="Condition"/>
+    <field reuseLastValue="0" name="Conifer"/>
+    <field reuseLastValue="0" name="ConversionCode"/>
+    <field reuseLastValue="0" name="ConversionID"/>
+    <field reuseLastValue="0" name="ConversionType"/>
+    <field reuseLastValue="0" name="Departure"/>
+    <field reuseLastValue="0" name="Devegetation"/>
+    <field reuseLastValue="0" name="Development"/>
+    <field reuseLastValue="0" name="ExistingRiparianMean"/>
+    <field reuseLastValue="0" name="FloodplainAccess"/>
+    <field reuseLastValue="0" name="FromConifer"/>
+    <field reuseLastValue="0" name="FromDevegetated"/>
+    <field reuseLastValue="0" name="FromGrassShrubland"/>
+    <field reuseLastValue="0" name="GrassShrubland"/>
+    <field reuseLastValue="0" name="HistoricRiparianMean"/>
+    <field reuseLastValue="0" name="Invasive"/>
+    <field reuseLastValue="0" name="LevelID"/>
+    <field reuseLastValue="0" name="NHDPlusID"/>
+    <field reuseLastValue="0" name="NoChange"/>
+    <field reuseLastValue="0" name="NonRiparian"/>
+    <field reuseLastValue="0" name="ReachCode"/>
+    <field reuseLastValue="0" name="ReachID"/>
+    <field reuseLastValue="0" name="RiparianDeparture"/>
+    <field reuseLastValue="0" name="RiparianDepartureID"/>
+    <field reuseLastValue="0" name="StreamName"/>
+    <field reuseLastValue="0" name="WatershedID"/>
+    <field reuseLastValue="0" name="iPC_LU"/>
+  </reuseLastValue>
+  <dataDefinedFieldProperties/>
+  <widgets/>
+  <previewExpression>"StreamName"</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>1</layerGeometryType>
 </qgis>

--- a/Symbology/qgis/RCAT/Veg_Conversion_raster.qml
+++ b/Symbology/qgis/RCAT/Veg_Conversion_raster.qml
@@ -1,18 +1,18 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="AllStyleCategories" version="3.30.2-'s-Hertogenbosch" hasScaleBasedVisibilityFlag="0" maxScale="0" minScale="0">
+<qgis styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" readOnly="0" labelsEnabled="0" maxScale="0" symbologyReferenceScale="-1" simplifyAlgorithm="0" version="3.30.2-'s-Hertogenbosch" simplifyMaxScale="1" simplifyLocal="1" simplifyDrawingTol="1" simplifyDrawingHints="1" minScale="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <temporal fetchMode="0" mode="0" enabled="0">
+  <temporal limitMode="0" enabled="0" startField="" endField="" accumulate="0" durationUnit="min" fixedDuration="0" mode="0" startExpression="" endExpression="" durationField="">
     <fixedRange>
       <start></start>
       <end></end>
     </fixedRange>
   </temporal>
-  <elevation zoffset="0" zscale="1" symbology="Line" enabled="0" band="1">
+  <elevation showMarkerSymbolInSurfacePlots="0" extrusion="0" binding="Centroid" zscale="1" extrusionEnabled="0" clamping="Terrain" type="IndividualFeatures" zoffset="0" symbology="Line" respectLayerSymbol="1">
     <data-defined-properties>
       <Option type="Map">
         <Option name="name" value="" type="QString"/>
@@ -21,7 +21,7 @@
       </Option>
     </data-defined-properties>
     <profileLineSymbol>
-      <symbol name="" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+      <symbol name="" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="line" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
             <Option name="name" value="" type="QString"/>
@@ -29,7 +29,7 @@
             <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleLine" id="{43472ddd-315b-4614-b84d-594ac41023f2}" pass="0" locked="0" enabled="1">
+        <layer id="{f4ecc64a-47b2-4044-9b08-4326b75808b7}" locked="0" enabled="1" class="SimpleLine" pass="0">
           <Option type="Map">
             <Option name="align_dash_pattern" value="0" type="QString"/>
             <Option name="capstyle" value="square" type="QString"/>
@@ -41,7 +41,7 @@
             <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
             <Option name="draw_inside_polygon" value="0" type="QString"/>
             <Option name="joinstyle" value="bevel" type="QString"/>
-            <Option name="line_color" value="133,182,111,255" type="QString"/>
+            <Option name="line_color" value="196,60,57,255" type="QString"/>
             <Option name="line_style" value="solid" type="QString"/>
             <Option name="line_width" value="0.6" type="QString"/>
             <Option name="line_width_unit" value="MM" type="QString"/>
@@ -70,7 +70,7 @@
       </symbol>
     </profileLineSymbol>
     <profileFillSymbol>
-      <symbol name="" force_rhr="0" alpha="1" clip_to_extent="1" type="fill" is_animated="0" frame_rate="10">
+      <symbol name="" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="fill" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
             <Option name="name" value="" type="QString"/>
@@ -78,17 +78,17 @@
             <Option name="type" value="collection" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" id="{f98db3c6-316f-403f-a1b2-5d698d654809}" pass="0" locked="0" enabled="1">
+        <layer id="{82c0d52f-6d3c-4f5e-b14c-fbbc93ff659e}" locked="0" enabled="1" class="SimpleFill" pass="0">
           <Option type="Map">
             <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-            <Option name="color" value="133,182,111,255" type="QString"/>
+            <Option name="color" value="196,60,57,255" type="QString"/>
             <Option name="joinstyle" value="bevel" type="QString"/>
             <Option name="offset" value="0,0" type="QString"/>
             <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
             <Option name="offset_unit" value="MM" type="QString"/>
-            <Option name="outline_color" value="35,35,35,255" type="QString"/>
-            <Option name="outline_style" value="no" type="QString"/>
-            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_color" value="140,43,41,255" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.2" type="QString"/>
             <Option name="outline_width_unit" value="MM" type="QString"/>
             <Option name="style" value="solid" type="QString"/>
           </Option>
@@ -102,84 +102,1304 @@
         </layer>
       </symbol>
     </profileFillSymbol>
+    <profileMarkerSymbol>
+      <symbol name="" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="marker" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{8625dc06-e17c-4f35-b924-e558d08547c3}" locked="0" enabled="1" class="SimpleMarker" pass="0">
+          <Option type="Map">
+            <Option name="angle" value="0" type="QString"/>
+            <Option name="cap_style" value="square" type="QString"/>
+            <Option name="color" value="196,60,57,255" type="QString"/>
+            <Option name="horizontal_anchor_point" value="1" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="name" value="diamond" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="140,43,41,255" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.2" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="scale_method" value="diameter" type="QString"/>
+            <Option name="size" value="3" type="QString"/>
+            <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="size_unit" value="MM" type="QString"/>
+            <Option name="vertical_anchor_point" value="1" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </profileMarkerSymbol>
   </elevation>
+  <renderer-v2 referencescale="-1" enableorderby="0" symbollevels="0" type="RuleRenderer" forceraster="0">
+    <rules key="{75dc028b-8625-4f2a-8134-41ce7bab962b}">
+      <rule label="Conv. To Agriculture" symbol="0" filter="&quot;ConversionCode&quot; in (41, 42, 43, 44)" key="{3a4c9d33-f0a8-46e0-8984-449c2d973754}"/>
+      <rule label="Conifer Encroachment" symbol="1" filter="&quot;ConversionCode&quot; in (29, 30, 31, 32)" key="{ddbfdb78-e322-4c14-b5c2-6dab1540f67d}"/>
+      <rule label="Conv. To Grass/Shrubland" symbol="2" filter="&quot;ConversionCode&quot; in (21, 22, 23, 24)" key="{a84a55e6-e8a1-43aa-be94-2bd1c965dd7b}"/>
+      <rule label="Conv. To Invasive" symbol="3" filter="&quot;ConversionCode&quot; in (33, 34, 35, 36)" key="{224bd769-f61b-4801-a2ca-24255e626b01}"/>
+      <rule label="Non-Riparian Conversions" symbol="4" filter="&quot;ConversionCode&quot; in (45, 46, 47, 48)" key="{97c4ec22-d7b3-404b-8e08-187f063b726f}"/>
+      <rule label="Devegetation" symbol="5" filter="&quot;ConversionCode&quot; in (25, 26, 27, 28)" key="{fff74000-5f09-4e8f-8fca-a6c1401c8925}"/>
+      <rule label="Developement" symbol="6" filter="&quot;ConversionCode&quot; in (37, 38, 39, 40)" key="{919f0df1-8e2e-45e0-8c85-9b25ad246754}"/>
+      <rule label="Multiple Conv. Types" symbol="7" filter="&quot;ConversionCode&quot; in (49, 50, 51, 52)" key="{74d61be2-95a5-4a1a-bc49-50a619bd38b3}"/>
+      <rule label="Negligible to Minor Veg. Conversion" symbol="8" filter="&quot;ConversionCode&quot; = 0" key="{71226376-9989-4e05-bf60-2466b47e70af}"/>
+      <rule label="From Grass/Shrubland to Riparian" symbol="9" filter="&quot;ConversionCode&quot; in (9, 10, 11, 12)" key="{f4ac2792-b1e7-4032-91a6-60a227011146}"/>
+      <rule label="From Devegetated to Riparian" symbol="10" filter="&quot;ConversionCode&quot; in (5, 6, 7, 8)" key="{ee66b604-3b9e-4583-b7b8-3b84d7210f9f}"/>
+      <rule label="From Conifer to Riparian" symbol="11" filter="&quot;ConversionCode&quot; in (1, 2, 3, 4)" key="{5bba7653-c1a8-45a3-b25b-0c69dcf6202a}"/>
+    </rules>
+    <symbols>
+      <symbol name="0" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="line" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{1478d543-300f-48bd-8dcb-a42edf41cfa2}" locked="0" enabled="1" class="SimpleLine" pass="0">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="229,229,21,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="1" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="line" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{1478d543-300f-48bd-8dcb-a42edf41cfa2}" locked="0" enabled="1" class="SimpleLine" pass="0">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="215,70,153,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="10" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="line" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{7a589f15-bd76-4ea9-8bf3-6afc1d6a6aba}" locked="0" enabled="1" class="SimpleLine" pass="0">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="247,214,167,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="11" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="line" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{653f3296-8026-43d6-93d4-604b4a7a21c2}" locked="0" enabled="1" class="SimpleLine" pass="0">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="242,209,228,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="2" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="line" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{1478d543-300f-48bd-8dcb-a42edf41cfa2}" locked="0" enabled="1" class="SimpleLine" pass="0">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="54,195,242,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="3" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="line" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{1478d543-300f-48bd-8dcb-a42edf41cfa2}" locked="0" enabled="1" class="SimpleLine" pass="0">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="137,76,158,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="4" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="line" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{1478d543-300f-48bd-8dcb-a42edf41cfa2}" locked="0" enabled="1" class="SimpleLine" pass="0">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="249,114,11,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="5" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="line" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{c5c5d67b-852a-4fda-8307-6d6a6d2e803c}" locked="0" enabled="1" class="SimpleLine" pass="0">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="166,116,42,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="6" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="line" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{2e4ec6cd-21ab-4f2d-89d8-95ffd7f98ed2}" locked="0" enabled="1" class="SimpleLine" pass="0">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="237,32,36,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="7" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="line" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{67c985ba-815f-449a-8732-b4c4b42684fe}" locked="0" enabled="1" class="SimpleLine" pass="0">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="79,79,79,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="8" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="line" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{e44d3714-0aa8-4006-bf19-8a63cf7bc9ad}" locked="0" enabled="1" class="SimpleLine" pass="0">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="109,190,69,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="9" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="line" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{1fd3bd45-eaf8-4477-9ddf-fbb45a16a860}" locked="0" enabled="1" class="SimpleLine" pass="0">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="215,235,242,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.26" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style textColor="0,0,0,255" fontWordSpacing="0" forcedBold="0" fieldName="&quot;StreamName&quot;" useSubstitutions="0" namedStyle="" textOrientation="horizontal" multilineHeightUnit="Percentage" fontFamily="Arial" multilineHeight="1" fontSize="8" fontWeight="16" allowHtml="0" textOpacity="1" previewBkgrdColor="255,255,255,255" fontItalic="0" forcedItalic="0" fontStrikeout="0" isExpression="1" blendMode="0" capitalization="0" fontLetterSpacing="0" fontUnderline="0" fontSizeUnit="Point" legendString="Aa" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontKerning="1">
+        <families/>
+        <text-buffer bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255" bufferJoinStyle="128" bufferSize="2" bufferSizeUnits="Point" bufferOpacity="1" bufferNoFill="1" bufferDraw="0"/>
+        <text-mask maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskType="0"/>
+        <background shapeRotationType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSVGFile="" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSizeType="0" shapeRadiiX="0" shapeFillColor="255,255,255,255" shapeBorderWidthUnit="MM" shapeSizeX="0" shapeRadiiUnit="MM" shapeRadiiY="0" shapeOffsetX="0" shapeBorderColor="128,128,128,255" shapeDraw="0" shapeType="0" shapeJoinStyle="64" shapeOpacity="1" shapeBlendMode="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeBorderWidth="0" shapeRotation="0" shapeOffsetY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeSizeY="0">
+          <symbol name="fillSymbol" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="fill" clip_to_extent="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer id="" locked="0" enabled="1" class="SimpleFill" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color" value="255,255,255,255" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="128,128,128,255" type="QString"/>
+                <Option name="outline_style" value="no" type="QString"/>
+                <Option name="outline_width" value="0" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="style" value="solid" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowRadius="1.5" shadowUnder="0" shadowDraw="0" shadowColor="0,0,0,255" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetAngle="135" shadowOffsetGlobal="1" shadowOffsetDist="1" shadowRadiusUnit="MM" shadowRadiusAlphaOnly="0" shadowOpacity="0.69999999999999996" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowScale="100"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </dd_properties>
+        <substitutions/>
+      </text-style>
+      <text-format placeDirectionSymbol="0" leftDirectionSymbol="&lt;" decimals="3" autoWrapLength="0" addDirectionSymbol="0" rightDirectionSymbol=">" plussign="0" multilineAlign="1" useMaxLineLengthForAutoWrap="1" wrapChar="" reverseDirectionSymbol="0" formatNumbers="0"/>
+      <placement preserveRotation="1" lineAnchorClipping="0" overrunDistanceUnit="MM" geometryGeneratorEnabled="0" fitInPolygonOnly="0" rotationAngle="0" distMapUnitScale="3x:0,0,0,0,0,0" centroidWhole="0" distUnits="Point" priority="10" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" quadOffset="4" layerType="UnknownGeometry" repeatDistanceUnits="MM" centroidInside="0" rotationUnit="AngleDegrees" offsetType="1" lineAnchorType="0" dist="0" geometryGenerator="" overlapHandling="PreventOverlap" lineAnchorPercent="0.5" placement="2" lineAnchorTextPoint="FollowPlacement" geometryGeneratorType="PointGeometry" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="10" allowDegraded="0" yOffset="0" maxCurvedCharAngleOut="-25" offsetUnits="MM" repeatDistance="0" overrunDistance="0" maxCurvedCharAngleIn="25" polygonPlacementFlags="2" xOffset="0"/>
+      <rendering scaleVisibility="0" unplacedVisibility="0" scaleMax="0" minFeatureSize="0" obstacleType="1" fontMinPixelSize="0" mergeLines="0" scaleMin="0" drawLabels="1" limitNumLabels="0" labelPerPart="0" zIndex="0" obstacle="0" fontLimitPixelSize="0" fontMaxPixelSize="10000" obstacleFactor="0" upsidedownLabels="0" maxNumLabels="2000"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option name="name" value="" type="QString"/>
+          <Option name="properties"/>
+          <Option name="type" value="collection" type="QString"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+          <Option name="blendMode" value="0" type="int"/>
+          <Option name="ddProperties" type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+          <Option name="drawToAllParts" value="false" type="bool"/>
+          <Option name="enabled" value="0" type="QString"/>
+          <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+          <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; is_animated=&quot;0&quot; alpha=&quot;1&quot; frame_rate=&quot;10&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; clip_to_extent=&quot;1&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer id=&quot;{336b07b8-4677-4228-b1a5-ae53d667c9c2}&quot; locked=&quot;0&quot; enabled=&quot;1&quot; class=&quot;SimpleLine&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+          <Option name="minLength" value="0" type="double"/>
+          <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="minLengthUnit" value="MM" type="QString"/>
+          <Option name="offsetFromAnchor" value="0" type="double"/>
+          <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+          <Option name="offsetFromLabel" value="0" type="double"/>
+          <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
   <customproperties>
     <Option type="Map">
-      <Option name="WMSBackgroundLayer" value="false" type="bool"/>
-      <Option name="WMSPublishDataSourceUrl" value="false" type="bool"/>
+      <Option name="dualview/previewExpressions" type="List">
+        <Option value="&quot;StreamName&quot;" type="QString"/>
+      </Option>
       <Option name="embeddedWidgets/count" value="0" type="int"/>
-      <Option name="identify/format" value="Value" type="QString"/>
+      <Option name="variableNames" type="invalid"/>
+      <Option name="variableValues" type="invalid"/>
     </Option>
   </customproperties>
-  <mapTip></mapTip>
-  <pipe-data-defined-properties>
-    <Option type="Map">
-      <Option name="name" value="" type="QString"/>
-      <Option name="properties"/>
-      <Option name="type" value="collection" type="QString"/>
-    </Option>
-  </pipe-data-defined-properties>
-  <pipe>
-    <provider>
-      <resampling maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" zoomedInResamplingMethod="nearestNeighbour" enabled="false"/>
-    </provider>
-    <rasterrenderer nodataColor="" classificationMax="1000" type="singlebandpseudocolor" opacity="0.6" band="1" classificationMin="-80" alphaBand="-1">
-      <rasterTransparency/>
-      <minMaxOrigin>
-        <limits>None</limits>
-        <extent>WholeRaster</extent>
-        <statAccuracy>Estimated</statAccuracy>
-        <cumulativeCutLower>0.02</cumulativeCutLower>
-        <cumulativeCutUpper>0.98</cumulativeCutUpper>
-        <stdDevFactor>2</stdDevFactor>
-      </minMaxOrigin>
-      <rastershader>
-        <colorrampshader minimumValue="-80" colorRampType="DISCRETE" classificationMode="1" maximumValue="1000" labelPrecision="0" clip="0">
-          <colorramp name="[source]" type="gradient">
-            <Option type="Map">
-              <Option name="color1" value="242,209,228,255" type="QString"/>
-              <Option name="color2" value="79,79,79,255" type="QString"/>
-              <Option name="direction" value="ccw" type="QString"/>
-              <Option name="discrete" value="0" type="QString"/>
-              <Option name="rampType" value="gradient" type="QString"/>
-              <Option name="spec" value="rgb" type="QString"/>
-              <Option name="stops" value="0.0185185;247,214,167,255;rgb;ccw:0.0277778;215,235,242,255;rgb;ccw:0.0740741;178,178,178,255;rgb;ccw:0.0741667;51,160,44,255;rgb;ccw:0.119444;178,178,178,255;rgb;ccw:0.12037;54,195,242,255;rgb;ccw:0.12963;166,116,42,255;rgb;ccw:0.148148;215,70,153,255;rgb;ccw:0.163889;137,76,158,255;rgb;ccw:0.164815;237,32,36,255;rgb;ccw:0.165741;229,229,21,255;rgb;ccw:0.166667;249,114,11,255;rgb;ccw" type="QString"/>
-            </Option>
-          </colorramp>
-          <item color="#f2d1e4" value="-80" alpha="255" label="From Conifer"/>
-          <item color="#f7d6a7" value="-60" alpha="255" label="From Devegetated"/>
-          <item color="#d7ebf2" value="-50" alpha="255" label="From Grass/Shrubland"/>
-          <item color="#b2b2b2" value="0" alpha="255" label="Upland Conversion"/>
-          <item color="#33a02c" value="0.1" alpha="255" label="No Change"/>
-          <item color="#b2b2b2" value="49" alpha="255" label="Upland Conversion"/>
-          <item color="#36c3f2" value="50" alpha="255" label="Grass/Shrubland"/>
-          <item color="#a6742a" value="60" alpha="255" label="Devegetation"/>
-          <item color="#d74699" value="80" alpha="255" label="Conifer"/>
-          <item color="#894c9e" value="97" alpha="255" label="Invasive"/>
-          <item color="#ed2024" value="98" alpha="255" label="Development"/>
-          <item color="#e5e515" value="99" alpha="255" label="Agriculture"/>
-          <item color="#f9720b" value="100" alpha="255" label="Non-Riparian Conversions "/>
-          <item color="#4f4f4f" value="1000" alpha="255" label="Multiple Dominant"/>
-          <rampLegendSettings useContinuousLegend="1" direction="0" prefix="" suffix="" orientation="2" maximumLabel="" minimumLabel="">
-            <numericFormat id="basic">
-              <Option type="Map">
-                <Option name="decimal_separator" type="invalid"/>
-                <Option name="decimals" value="6" type="int"/>
-                <Option name="rounding_type" value="0" type="int"/>
-                <Option name="show_plus" value="false" type="bool"/>
-                <Option name="show_thousand_separator" value="true" type="bool"/>
-                <Option name="show_trailing_zeros" value="false" type="bool"/>
-                <Option name="thousand_separator" type="invalid"/>
-              </Option>
-            </numericFormat>
-          </rampLegendSettings>
-        </colorrampshader>
-      </rastershader>
-    </rasterrenderer>
-    <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
-    <huesaturation colorizeOn="0" colorizeStrength="100" invertColors="0" colorizeRed="255" saturation="0" colorizeGreen="128" colorizeBlue="128" grayscaleMode="0"/>
-    <rasterresampler maxOversampling="2"/>
-    <resamplingStage>resamplingFilter</resamplingStage>
-  </pipe>
   <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+    <DiagramCategory backgroundAlpha="255" spacing="5" sizeType="MM" minScaleDenominator="0" opacity="1" spacingUnitScale="3x:0,0,0,0,0,0" barWidth="5" width="15" penWidth="0" direction="0" lineSizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" maxScaleDenominator="0" labelPlacementMethod="XHeight" penColor="#000000" height="15" penAlpha="255" backgroundColor="#ffffff" diagramOrientation="Up" rotationOffset="270" showAxis="1" enabled="0" scaleBasedVisibility="0" sizeScale="3x:0,0,0,0,0,0" spacingUnit="MM" minimumSize="0" lineSizeType="MM">
+      <fontProperties description="MS Shell Dlg 2,7.8,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" style="" underline="0" italic="0"/>
+      <attribute colorOpacity="1" field="" label="" color="#000000"/>
+      <axisSymbol>
+        <symbol name="" is_animated="0" alpha="1" frame_rate="10" force_rhr="0" type="line" clip_to_extent="1">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+          <layer id="{aa1b8866-528d-41d5-aef8-0c8a53abb89f}" locked="0" enabled="1" class="SimpleLine" pass="0">
+            <Option type="Map">
+              <Option name="align_dash_pattern" value="0" type="QString"/>
+              <Option name="capstyle" value="square" type="QString"/>
+              <Option name="customdash" value="5;2" type="QString"/>
+              <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="customdash_unit" value="MM" type="QString"/>
+              <Option name="dash_pattern_offset" value="0" type="QString"/>
+              <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+              <Option name="draw_inside_polygon" value="0" type="QString"/>
+              <Option name="joinstyle" value="bevel" type="QString"/>
+              <Option name="line_color" value="35,35,35,255" type="QString"/>
+              <Option name="line_style" value="solid" type="QString"/>
+              <Option name="line_width" value="0.26" type="QString"/>
+              <Option name="line_width_unit" value="MM" type="QString"/>
+              <Option name="offset" value="0" type="QString"/>
+              <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offset_unit" value="MM" type="QString"/>
+              <Option name="ring_filter" value="0" type="QString"/>
+              <Option name="trim_distance_end" value="0" type="QString"/>
+              <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+              <Option name="trim_distance_start" value="0" type="QString"/>
+              <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+              <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+              <Option name="use_custom_dash" value="0" type="QString"/>
+              <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            </Option>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </axisSymbol>
+    </DiagramCategory>
+  </SingleCategoryDiagramRenderer>
+  <DiagramLayerSettings placement="2" showAll="1" linePlacementFlags="18" priority="0" zIndex="0" obstacle="0" dist="0">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <legend showLabelLegend="0" type="default-vector"/>
+  <referencedLayers/>
+  <fieldConfiguration>
+    <field name="ReachID" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ReachCode" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="WatershedID" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="StreamName" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="NHDPlusID" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="iPC_LU" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="FloodplainAccess" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="FromConifer" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="FromDevegetated" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="FromGrassShrubland" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="NoChange" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="GrassShrubland" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Devegetation" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Conifer" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Invasive" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Development" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Agriculture" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="NonRiparian" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ConversionID" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="LevelID" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ExistingRiparianMean" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="HistoricRiparianMean" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="RiparianDeparture" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="RiparianDepartureID" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Condition" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ConversionCode" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ConversionType" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Departure" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias name="" field="ReachID" index="0"/>
+    <alias name="" field="ReachCode" index="1"/>
+    <alias name="" field="WatershedID" index="2"/>
+    <alias name="" field="StreamName" index="3"/>
+    <alias name="" field="NHDPlusID" index="4"/>
+    <alias name="" field="iPC_LU" index="5"/>
+    <alias name="" field="FloodplainAccess" index="6"/>
+    <alias name="" field="FromConifer" index="7"/>
+    <alias name="" field="FromDevegetated" index="8"/>
+    <alias name="" field="FromGrassShrubland" index="9"/>
+    <alias name="" field="NoChange" index="10"/>
+    <alias name="" field="GrassShrubland" index="11"/>
+    <alias name="" field="Devegetation" index="12"/>
+    <alias name="" field="Conifer" index="13"/>
+    <alias name="" field="Invasive" index="14"/>
+    <alias name="" field="Development" index="15"/>
+    <alias name="" field="Agriculture" index="16"/>
+    <alias name="" field="NonRiparian" index="17"/>
+    <alias name="" field="ConversionID" index="18"/>
+    <alias name="" field="LevelID" index="19"/>
+    <alias name="" field="ExistingRiparianMean" index="20"/>
+    <alias name="" field="HistoricRiparianMean" index="21"/>
+    <alias name="" field="RiparianDeparture" index="22"/>
+    <alias name="" field="RiparianDepartureID" index="23"/>
+    <alias name="" field="Condition" index="24"/>
+    <alias name="" field="ConversionCode" index="25"/>
+    <alias name="" field="ConversionType" index="26"/>
+    <alias name="" field="Departure" index="27"/>
+  </aliases>
+  <splitPolicies>
+    <policy field="ReachID" policy="Duplicate"/>
+    <policy field="ReachCode" policy="Duplicate"/>
+    <policy field="WatershedID" policy="Duplicate"/>
+    <policy field="StreamName" policy="Duplicate"/>
+    <policy field="NHDPlusID" policy="Duplicate"/>
+    <policy field="iPC_LU" policy="Duplicate"/>
+    <policy field="FloodplainAccess" policy="Duplicate"/>
+    <policy field="FromConifer" policy="Duplicate"/>
+    <policy field="FromDevegetated" policy="Duplicate"/>
+    <policy field="FromGrassShrubland" policy="Duplicate"/>
+    <policy field="NoChange" policy="Duplicate"/>
+    <policy field="GrassShrubland" policy="Duplicate"/>
+    <policy field="Devegetation" policy="Duplicate"/>
+    <policy field="Conifer" policy="Duplicate"/>
+    <policy field="Invasive" policy="Duplicate"/>
+    <policy field="Development" policy="Duplicate"/>
+    <policy field="Agriculture" policy="Duplicate"/>
+    <policy field="NonRiparian" policy="Duplicate"/>
+    <policy field="ConversionID" policy="Duplicate"/>
+    <policy field="LevelID" policy="Duplicate"/>
+    <policy field="ExistingRiparianMean" policy="Duplicate"/>
+    <policy field="HistoricRiparianMean" policy="Duplicate"/>
+    <policy field="RiparianDeparture" policy="Duplicate"/>
+    <policy field="RiparianDepartureID" policy="Duplicate"/>
+    <policy field="Condition" policy="Duplicate"/>
+    <policy field="ConversionCode" policy="Duplicate"/>
+    <policy field="ConversionType" policy="Duplicate"/>
+    <policy field="Departure" policy="Duplicate"/>
+  </splitPolicies>
+  <defaults>
+    <default expression="" field="ReachID" applyOnUpdate="0"/>
+    <default expression="" field="ReachCode" applyOnUpdate="0"/>
+    <default expression="" field="WatershedID" applyOnUpdate="0"/>
+    <default expression="" field="StreamName" applyOnUpdate="0"/>
+    <default expression="" field="NHDPlusID" applyOnUpdate="0"/>
+    <default expression="" field="iPC_LU" applyOnUpdate="0"/>
+    <default expression="" field="FloodplainAccess" applyOnUpdate="0"/>
+    <default expression="" field="FromConifer" applyOnUpdate="0"/>
+    <default expression="" field="FromDevegetated" applyOnUpdate="0"/>
+    <default expression="" field="FromGrassShrubland" applyOnUpdate="0"/>
+    <default expression="" field="NoChange" applyOnUpdate="0"/>
+    <default expression="" field="GrassShrubland" applyOnUpdate="0"/>
+    <default expression="" field="Devegetation" applyOnUpdate="0"/>
+    <default expression="" field="Conifer" applyOnUpdate="0"/>
+    <default expression="" field="Invasive" applyOnUpdate="0"/>
+    <default expression="" field="Development" applyOnUpdate="0"/>
+    <default expression="" field="Agriculture" applyOnUpdate="0"/>
+    <default expression="" field="NonRiparian" applyOnUpdate="0"/>
+    <default expression="" field="ConversionID" applyOnUpdate="0"/>
+    <default expression="" field="LevelID" applyOnUpdate="0"/>
+    <default expression="" field="ExistingRiparianMean" applyOnUpdate="0"/>
+    <default expression="" field="HistoricRiparianMean" applyOnUpdate="0"/>
+    <default expression="" field="RiparianDeparture" applyOnUpdate="0"/>
+    <default expression="" field="RiparianDepartureID" applyOnUpdate="0"/>
+    <default expression="" field="Condition" applyOnUpdate="0"/>
+    <default expression="" field="ConversionCode" applyOnUpdate="0"/>
+    <default expression="" field="ConversionType" applyOnUpdate="0"/>
+    <default expression="" field="Departure" applyOnUpdate="0"/>
+  </defaults>
+  <constraints>
+    <constraint constraints="3" field="ReachID" exp_strength="0" notnull_strength="1" unique_strength="1"/>
+    <constraint constraints="0" field="ReachCode" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="WatershedID" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="StreamName" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="NHDPlusID" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="iPC_LU" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="FloodplainAccess" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="FromConifer" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="FromDevegetated" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="FromGrassShrubland" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="NoChange" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="GrassShrubland" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="Devegetation" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="Conifer" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="Invasive" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="Development" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="Agriculture" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="NonRiparian" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="ConversionID" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="LevelID" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="ExistingRiparianMean" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="HistoricRiparianMean" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="RiparianDeparture" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="RiparianDepartureID" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="Condition" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="ConversionCode" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="ConversionType" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+    <constraint constraints="0" field="Departure" exp_strength="0" notnull_strength="0" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint exp="" field="ReachID" desc=""/>
+    <constraint exp="" field="ReachCode" desc=""/>
+    <constraint exp="" field="WatershedID" desc=""/>
+    <constraint exp="" field="StreamName" desc=""/>
+    <constraint exp="" field="NHDPlusID" desc=""/>
+    <constraint exp="" field="iPC_LU" desc=""/>
+    <constraint exp="" field="FloodplainAccess" desc=""/>
+    <constraint exp="" field="FromConifer" desc=""/>
+    <constraint exp="" field="FromDevegetated" desc=""/>
+    <constraint exp="" field="FromGrassShrubland" desc=""/>
+    <constraint exp="" field="NoChange" desc=""/>
+    <constraint exp="" field="GrassShrubland" desc=""/>
+    <constraint exp="" field="Devegetation" desc=""/>
+    <constraint exp="" field="Conifer" desc=""/>
+    <constraint exp="" field="Invasive" desc=""/>
+    <constraint exp="" field="Development" desc=""/>
+    <constraint exp="" field="Agriculture" desc=""/>
+    <constraint exp="" field="NonRiparian" desc=""/>
+    <constraint exp="" field="ConversionID" desc=""/>
+    <constraint exp="" field="LevelID" desc=""/>
+    <constraint exp="" field="ExistingRiparianMean" desc=""/>
+    <constraint exp="" field="HistoricRiparianMean" desc=""/>
+    <constraint exp="" field="RiparianDeparture" desc=""/>
+    <constraint exp="" field="RiparianDepartureID" desc=""/>
+    <constraint exp="" field="Condition" desc=""/>
+    <constraint exp="" field="ConversionCode" desc=""/>
+    <constraint exp="" field="ConversionType" desc=""/>
+    <constraint exp="" field="Departure" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortOrder="1" actionWidgetStyle="dropDown" sortExpression="&quot;FloodplainAccess&quot;">
+    <columns>
+      <column name="ReachID" width="-1" type="field" hidden="0"/>
+      <column name="ReachCode" width="-1" type="field" hidden="0"/>
+      <column name="WatershedID" width="-1" type="field" hidden="0"/>
+      <column name="StreamName" width="-1" type="field" hidden="0"/>
+      <column name="NHDPlusID" width="-1" type="field" hidden="0"/>
+      <column name="iPC_LU" width="-1" type="field" hidden="0"/>
+      <column name="FloodplainAccess" width="-1" type="field" hidden="0"/>
+      <column name="FromConifer" width="-1" type="field" hidden="0"/>
+      <column name="FromDevegetated" width="-1" type="field" hidden="0"/>
+      <column name="FromGrassShrubland" width="-1" type="field" hidden="0"/>
+      <column name="NoChange" width="-1" type="field" hidden="0"/>
+      <column name="GrassShrubland" width="-1" type="field" hidden="0"/>
+      <column name="Devegetation" width="-1" type="field" hidden="0"/>
+      <column name="Conifer" width="-1" type="field" hidden="0"/>
+      <column name="Invasive" width="-1" type="field" hidden="0"/>
+      <column name="Development" width="-1" type="field" hidden="0"/>
+      <column name="Agriculture" width="-1" type="field" hidden="0"/>
+      <column name="NonRiparian" width="-1" type="field" hidden="0"/>
+      <column name="ConversionID" width="-1" type="field" hidden="0"/>
+      <column name="LevelID" width="-1" type="field" hidden="0"/>
+      <column name="ExistingRiparianMean" width="-1" type="field" hidden="0"/>
+      <column name="HistoricRiparianMean" width="-1" type="field" hidden="0"/>
+      <column name="RiparianDeparture" width="-1" type="field" hidden="0"/>
+      <column name="RiparianDepartureID" width="-1" type="field" hidden="0"/>
+      <column name="Condition" width="-1" type="field" hidden="0"/>
+      <column name="ConversionCode" width="-1" type="field" hidden="0"/>
+      <column name="ConversionType" width="-1" type="field" hidden="0"/>
+      <column name="Departure" width="-1" type="field" hidden="0"/>
+      <column width="-1" type="actions" hidden="1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <storedexpressions/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>generatedlayout</editorlayout>
+  <editable>
+    <field name="Agriculture" editable="1"/>
+    <field name="Condition" editable="1"/>
+    <field name="Conifer" editable="1"/>
+    <field name="ConversionCode" editable="1"/>
+    <field name="ConversionID" editable="1"/>
+    <field name="ConversionType" editable="1"/>
+    <field name="Departure" editable="1"/>
+    <field name="Devegetation" editable="1"/>
+    <field name="Development" editable="1"/>
+    <field name="ExistingRiparianMean" editable="1"/>
+    <field name="FloodplainAccess" editable="1"/>
+    <field name="FromConifer" editable="1"/>
+    <field name="FromDevegetated" editable="1"/>
+    <field name="FromGrassShrubland" editable="1"/>
+    <field name="GrassShrubland" editable="1"/>
+    <field name="HistoricRiparianMean" editable="1"/>
+    <field name="Invasive" editable="1"/>
+    <field name="LevelID" editable="1"/>
+    <field name="NHDPlusID" editable="1"/>
+    <field name="NoChange" editable="1"/>
+    <field name="NonRiparian" editable="1"/>
+    <field name="ReachCode" editable="1"/>
+    <field name="ReachID" editable="1"/>
+    <field name="RiparianDeparture" editable="1"/>
+    <field name="RiparianDepartureID" editable="1"/>
+    <field name="StreamName" editable="1"/>
+    <field name="WatershedID" editable="1"/>
+    <field name="iPC_LU" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="Agriculture" labelOnTop="0"/>
+    <field name="Condition" labelOnTop="0"/>
+    <field name="Conifer" labelOnTop="0"/>
+    <field name="ConversionCode" labelOnTop="0"/>
+    <field name="ConversionID" labelOnTop="0"/>
+    <field name="ConversionType" labelOnTop="0"/>
+    <field name="Departure" labelOnTop="0"/>
+    <field name="Devegetation" labelOnTop="0"/>
+    <field name="Development" labelOnTop="0"/>
+    <field name="ExistingRiparianMean" labelOnTop="0"/>
+    <field name="FloodplainAccess" labelOnTop="0"/>
+    <field name="FromConifer" labelOnTop="0"/>
+    <field name="FromDevegetated" labelOnTop="0"/>
+    <field name="FromGrassShrubland" labelOnTop="0"/>
+    <field name="GrassShrubland" labelOnTop="0"/>
+    <field name="HistoricRiparianMean" labelOnTop="0"/>
+    <field name="Invasive" labelOnTop="0"/>
+    <field name="LevelID" labelOnTop="0"/>
+    <field name="NHDPlusID" labelOnTop="0"/>
+    <field name="NoChange" labelOnTop="0"/>
+    <field name="NonRiparian" labelOnTop="0"/>
+    <field name="ReachCode" labelOnTop="0"/>
+    <field name="ReachID" labelOnTop="0"/>
+    <field name="RiparianDeparture" labelOnTop="0"/>
+    <field name="RiparianDepartureID" labelOnTop="0"/>
+    <field name="StreamName" labelOnTop="0"/>
+    <field name="WatershedID" labelOnTop="0"/>
+    <field name="iPC_LU" labelOnTop="0"/>
+  </labelOnTop>
+  <reuseLastValue>
+    <field name="Agriculture" reuseLastValue="0"/>
+    <field name="Condition" reuseLastValue="0"/>
+    <field name="Conifer" reuseLastValue="0"/>
+    <field name="ConversionCode" reuseLastValue="0"/>
+    <field name="ConversionID" reuseLastValue="0"/>
+    <field name="ConversionType" reuseLastValue="0"/>
+    <field name="Departure" reuseLastValue="0"/>
+    <field name="Devegetation" reuseLastValue="0"/>
+    <field name="Development" reuseLastValue="0"/>
+    <field name="ExistingRiparianMean" reuseLastValue="0"/>
+    <field name="FloodplainAccess" reuseLastValue="0"/>
+    <field name="FromConifer" reuseLastValue="0"/>
+    <field name="FromDevegetated" reuseLastValue="0"/>
+    <field name="FromGrassShrubland" reuseLastValue="0"/>
+    <field name="GrassShrubland" reuseLastValue="0"/>
+    <field name="HistoricRiparianMean" reuseLastValue="0"/>
+    <field name="Invasive" reuseLastValue="0"/>
+    <field name="LevelID" reuseLastValue="0"/>
+    <field name="NHDPlusID" reuseLastValue="0"/>
+    <field name="NoChange" reuseLastValue="0"/>
+    <field name="NonRiparian" reuseLastValue="0"/>
+    <field name="ReachCode" reuseLastValue="0"/>
+    <field name="ReachID" reuseLastValue="0"/>
+    <field name="RiparianDeparture" reuseLastValue="0"/>
+    <field name="RiparianDepartureID" reuseLastValue="0"/>
+    <field name="StreamName" reuseLastValue="0"/>
+    <field name="WatershedID" reuseLastValue="0"/>
+    <field name="iPC_LU" reuseLastValue="0"/>
+  </reuseLastValue>
+  <dataDefinedFieldProperties/>
+  <widgets/>
+  <previewExpression>"StreamName"</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>1</layerGeometryType>
 </qgis>

--- a/Symbology/qgis/RCAT/Veg_Conversion_raster.qml
+++ b/Symbology/qgis/RCAT/Veg_Conversion_raster.qml
@@ -1,0 +1,185 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="AllStyleCategories" version="3.30.2-'s-Hertogenbosch" hasScaleBasedVisibilityFlag="0" maxScale="0" minScale="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <temporal fetchMode="0" mode="0" enabled="0">
+    <fixedRange>
+      <start></start>
+      <end></end>
+    </fixedRange>
+  </temporal>
+  <elevation zoffset="0" zscale="1" symbology="Line" enabled="0" band="1">
+    <data-defined-properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </data-defined-properties>
+    <profileLineSymbol>
+      <symbol name="" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" id="{43472ddd-315b-4614-b84d-594ac41023f2}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="133,182,111,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.6" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </profileLineSymbol>
+    <profileFillSymbol>
+      <symbol name="" force_rhr="0" alpha="1" clip_to_extent="1" type="fill" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" id="{f98db3c6-316f-403f-a1b2-5d698d654809}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="133,182,111,255" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255" type="QString"/>
+            <Option name="outline_style" value="no" type="QString"/>
+            <Option name="outline_width" value="0.26" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </profileFillSymbol>
+  </elevation>
+  <customproperties>
+    <Option type="Map">
+      <Option name="WMSBackgroundLayer" value="false" type="bool"/>
+      <Option name="WMSPublishDataSourceUrl" value="false" type="bool"/>
+      <Option name="embeddedWidgets/count" value="0" type="int"/>
+      <Option name="identify/format" value="Value" type="QString"/>
+    </Option>
+  </customproperties>
+  <mapTip></mapTip>
+  <pipe-data-defined-properties>
+    <Option type="Map">
+      <Option name="name" value="" type="QString"/>
+      <Option name="properties"/>
+      <Option name="type" value="collection" type="QString"/>
+    </Option>
+  </pipe-data-defined-properties>
+  <pipe>
+    <provider>
+      <resampling maxOversampling="2" zoomedOutResamplingMethod="nearestNeighbour" zoomedInResamplingMethod="nearestNeighbour" enabled="false"/>
+    </provider>
+    <rasterrenderer nodataColor="" classificationMax="1000" type="singlebandpseudocolor" opacity="0.6" band="1" classificationMin="-80" alphaBand="-1">
+      <rasterTransparency/>
+      <minMaxOrigin>
+        <limits>None</limits>
+        <extent>WholeRaster</extent>
+        <statAccuracy>Estimated</statAccuracy>
+        <cumulativeCutLower>0.02</cumulativeCutLower>
+        <cumulativeCutUpper>0.98</cumulativeCutUpper>
+        <stdDevFactor>2</stdDevFactor>
+      </minMaxOrigin>
+      <rastershader>
+        <colorrampshader minimumValue="-80" colorRampType="DISCRETE" classificationMode="1" maximumValue="1000" labelPrecision="0" clip="0">
+          <colorramp name="[source]" type="gradient">
+            <Option type="Map">
+              <Option name="color1" value="242,209,228,255" type="QString"/>
+              <Option name="color2" value="79,79,79,255" type="QString"/>
+              <Option name="direction" value="ccw" type="QString"/>
+              <Option name="discrete" value="0" type="QString"/>
+              <Option name="rampType" value="gradient" type="QString"/>
+              <Option name="spec" value="rgb" type="QString"/>
+              <Option name="stops" value="0.0185185;247,214,167,255;rgb;ccw:0.0277778;215,235,242,255;rgb;ccw:0.0740741;178,178,178,255;rgb;ccw:0.0741667;51,160,44,255;rgb;ccw:0.119444;178,178,178,255;rgb;ccw:0.12037;54,195,242,255;rgb;ccw:0.12963;166,116,42,255;rgb;ccw:0.148148;215,70,153,255;rgb;ccw:0.163889;137,76,158,255;rgb;ccw:0.164815;237,32,36,255;rgb;ccw:0.165741;229,229,21,255;rgb;ccw:0.166667;249,114,11,255;rgb;ccw" type="QString"/>
+            </Option>
+          </colorramp>
+          <item color="#f2d1e4" value="-80" alpha="255" label="From Conifer"/>
+          <item color="#f7d6a7" value="-60" alpha="255" label="From Devegetated"/>
+          <item color="#d7ebf2" value="-50" alpha="255" label="From Grass/Shrubland"/>
+          <item color="#b2b2b2" value="0" alpha="255" label="Upland Conversion"/>
+          <item color="#33a02c" value="0.1" alpha="255" label="No Change"/>
+          <item color="#b2b2b2" value="49" alpha="255" label="Upland Conversion"/>
+          <item color="#36c3f2" value="50" alpha="255" label="Grass/Shrubland"/>
+          <item color="#a6742a" value="60" alpha="255" label="Devegetation"/>
+          <item color="#d74699" value="80" alpha="255" label="Conifer"/>
+          <item color="#894c9e" value="97" alpha="255" label="Invasive"/>
+          <item color="#ed2024" value="98" alpha="255" label="Development"/>
+          <item color="#e5e515" value="99" alpha="255" label="Agriculture"/>
+          <item color="#f9720b" value="100" alpha="255" label="Non-Riparian Conversions "/>
+          <item color="#4f4f4f" value="1000" alpha="255" label="Multiple Dominant"/>
+          <rampLegendSettings useContinuousLegend="1" direction="0" prefix="" suffix="" orientation="2" maximumLabel="" minimumLabel="">
+            <numericFormat id="basic">
+              <Option type="Map">
+                <Option name="decimal_separator" type="invalid"/>
+                <Option name="decimals" value="6" type="int"/>
+                <Option name="rounding_type" value="0" type="int"/>
+                <Option name="show_plus" value="false" type="bool"/>
+                <Option name="show_thousand_separator" value="true" type="bool"/>
+                <Option name="show_trailing_zeros" value="false" type="bool"/>
+                <Option name="thousand_separator" type="invalid"/>
+              </Option>
+            </numericFormat>
+          </rampLegendSettings>
+        </colorrampshader>
+      </rastershader>
+    </rasterrenderer>
+    <brightnesscontrast brightness="0" contrast="0" gamma="1"/>
+    <huesaturation colorizeOn="0" colorizeStrength="100" invertColors="0" colorizeRed="255" saturation="0" colorizeGreen="128" colorizeBlue="128" grayscaleMode="0"/>
+    <rasterresampler maxOversampling="2"/>
+    <resamplingStage>resamplingFilter</resamplingStage>
+  </pipe>
+  <blendMode>0</blendMode>
+</qgis>

--- a/Symbology/qgis/RCAT/Veg_conversion_igo.qml
+++ b/Symbology/qgis/RCAT/Veg_conversion_igo.qml
@@ -156,7 +156,7 @@
       <rule filter="&quot;ConversionCode&quot; in (49, 50, 51, 52)" symbol="7" label="Multiple Conv. Types" key="{c693bbe9-3593-47b1-84cf-dde7048f2210}"/>
       <rule filter="&quot;ConversionCode&quot; = 0" symbol="8" label="Negligible to Minor Veg. Conversion" key="{2431703c-a827-428f-af83-c139029ee477}"/>
       <rule filter="&quot;ConversionCode&quot; = (9, 10, 11, 12)" symbol="9" label="From Grass/Shrubland to Riparian" key="{3a81613c-e8e8-4327-afd4-1e8d1d058e64}"/>
-      <rule filter="&quot;ConversionCode&quot; in (5, 6, 7, 8)" symbol="10" label="From Devegetated to Riparian" key="{e7a97fdf-477c-41ad-b89a-a59ca18323d3}"/>
+      <rule filter="&quot;ConversionCode&quot; in (5, 6, 7, 8)" symbol="10" label="From Devegetated to Riparian" key="{b074bfb5-0334-49ac-a74c-84bb0eaf347e}"/>
       <rule filter="&quot;ConversionCode&quot; in (1, 2, 3, 4)" symbol="11" label="From Conifer to Riparian" key="{5bd42e75-180b-4cb0-8e73-e7722dbddeae}"/>
     </rules>
     <symbols>
@@ -294,7 +294,7 @@
           <Option type="Map">
             <Option name="angle" value="0" type="QString"/>
             <Option name="cap_style" value="square" type="QString"/>
-            <Option name="color" value="31,47,231,255" type="QString"/>
+            <Option name="color" value="247,214,167,255" type="QString"/>
             <Option name="horizontal_anchor_point" value="1" type="QString"/>
             <Option name="joinstyle" value="miter" type="QString"/>
             <Option name="name" value="circle" type="QString"/>
@@ -355,7 +355,7 @@
           <Option type="Map">
             <Option name="angle" value="0" type="QString"/>
             <Option name="cap_style" value="square" type="QString"/>
-            <Option name="color" value="147,246,170,255" type="QString"/>
+            <Option name="color" value="242,209,228,255" type="QString"/>
             <Option name="horizontal_anchor_point" value="1" type="QString"/>
             <Option name="joinstyle" value="miter" type="QString"/>
             <Option name="name" value="circle" type="QString"/>
@@ -843,7 +843,7 @@
           <Option type="Map">
             <Option name="angle" value="0" type="QString"/>
             <Option name="cap_style" value="square" type="QString"/>
-            <Option name="color" value="31,218,231,255" type="QString"/>
+            <Option name="color" value="215,235,242,255" type="QString"/>
             <Option name="horizontal_anchor_point" value="1" type="QString"/>
             <Option name="joinstyle" value="miter" type="QString"/>
             <Option name="name" value="circle" type="QString"/>

--- a/Symbology/qgis/RCAT/Veg_conversion_igo.qml
+++ b/Symbology/qgis/RCAT/Veg_conversion_igo.qml
@@ -146,8 +146,8 @@
   </elevation>
   <renderer-v2 symbollevels="0" type="RuleRenderer" enableorderby="0" referencescale="-1" forceraster="0">
     <rules key="{63c09983-2d26-4579-ac80-dd9769b8f68f}">
-      <rule filter="&quot;ConversionCode&quot; in (41, 42, 43, 44)" symbol="0" label="Conifer Encroachment" key="{84fc2890-f3cf-4ebc-8e24-5a58ad5c7037}"/>
-      <rule filter="&quot;ConversionCode&quot; in (29, 30, 31, 32)" symbol="1" label="Conv. To Agriculture" key="{18195d90-873a-4d0b-a2c6-5e8e4ab461e7}"/>
+      <rule filter="&quot;ConversionCode&quot; in (29, 30, 21, 32)" symbol="0" label="Conifer Encroachment" key="{84fc2890-f3cf-4ebc-8e24-5a58ad5c7037}"/>
+      <rule filter="&quot;ConversionCode&quot; in (41, 42, 43, 44)" symbol="1" label="Conv. To Agriculture" key="{18195d90-873a-4d0b-a2c6-5e8e4ab461e7}"/>
       <rule filter="&quot;ConversionCode&quot; in (21, 22, 23, 24)" symbol="2" label="Conv. To Grass/Shrubland" key="{6ceb3524-7a7e-4655-8e7d-8ec8607a434b}"/>
       <rule filter="&quot;ConversionCode&quot; in (33, 34, 35, 36)" symbol="3" label="Conv. To Invasive" key="{efa7d8f6-34d0-4c9d-902b-da6c077f664d}"/>
       <rule filter="&quot;ConversionCode&quot; in (45, 46, 47, 48)" symbol="4" label="Non-Riparian Conversions" key="{5c284893-11bc-4a05-867e-43d669e0b9a4}"/>
@@ -155,7 +155,7 @@
       <rule filter="&quot;ConversionCode&quot; in (37, 38, 39, 40)" symbol="6" label="Development" key="{7a9ad057-6889-495f-b9b0-37ed9c1b9664}"/>
       <rule filter="&quot;ConversionCode&quot; in (49, 50, 51, 52)" symbol="7" label="Multiple Conv. Types" key="{c693bbe9-3593-47b1-84cf-dde7048f2210}"/>
       <rule filter="&quot;ConversionCode&quot; = 0" symbol="8" label="Negligible to Minor Veg. Conversion" key="{2431703c-a827-428f-af83-c139029ee477}"/>
-      <rule filter="&quot;ConversionCode&quot; = (9, 10, 11, 12)" symbol="9" label="From Grass/Shrubland to Riparian" key="{3a81613c-e8e8-4327-afd4-1e8d1d058e64}"/>
+      <rule filter="&quot;ConversionCode&quot; in (9, 10, 11, 12)" symbol="9" label="From Grass/Shrubland to Riparian" key="{3a81613c-e8e8-4327-afd4-1e8d1d058e64}"/>
       <rule filter="&quot;ConversionCode&quot; in (5, 6, 7, 8)" symbol="10" label="From Devegetated to Riparian" key="{b074bfb5-0334-49ac-a74c-84bb0eaf347e}"/>
       <rule filter="&quot;ConversionCode&quot; in (1, 2, 3, 4)" symbol="11" label="From Conifer to Riparian" key="{5bd42e75-180b-4cb0-8e73-e7722dbddeae}"/>
     </rules>

--- a/Symbology/qgis/RCAT/Veg_conversion_igo.qml
+++ b/Symbology/qgis/RCAT/Veg_conversion_igo.qml
@@ -1,0 +1,1578 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis simplifyDrawingTol="1" labelsEnabled="0" styleCategories="AllStyleCategories" version="3.30.2-'s-Hertogenbosch" simplifyLocal="1" simplifyDrawingHints="0" symbologyReferenceScale="-1" hasScaleBasedVisibilityFlag="0" maxScale="0" minScale="0" simplifyAlgorithm="0" simplifyMaxScale="1" readOnly="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <temporal durationField="" mode="0" limitMode="0" endField="" startExpression="" durationUnit="min" fixedDuration="0" startField="" endExpression="" enabled="0" accumulate="0">
+    <fixedRange>
+      <start></start>
+      <end></end>
+    </fixedRange>
+  </temporal>
+  <elevation zoffset="0" clamping="Terrain" extrusion="0" binding="Centroid" zscale="1" respectLayerSymbol="1" type="IndividualFeatures" symbology="Line" showMarkerSymbolInSurfacePlots="0" extrusionEnabled="0">
+    <data-defined-properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </data-defined-properties>
+    <profileLineSymbol>
+      <symbol name="" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" id="{4a8547a5-be67-41f3-84f3-5f363a563117}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="align_dash_pattern" value="0" type="QString"/>
+            <Option name="capstyle" value="square" type="QString"/>
+            <Option name="customdash" value="5;2" type="QString"/>
+            <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="customdash_unit" value="MM" type="QString"/>
+            <Option name="dash_pattern_offset" value="0" type="QString"/>
+            <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+            <Option name="draw_inside_polygon" value="0" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="line_color" value="229,182,54,255" type="QString"/>
+            <Option name="line_style" value="solid" type="QString"/>
+            <Option name="line_width" value="0.6" type="QString"/>
+            <Option name="line_width_unit" value="MM" type="QString"/>
+            <Option name="offset" value="0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="ring_filter" value="0" type="QString"/>
+            <Option name="trim_distance_end" value="0" type="QString"/>
+            <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+            <Option name="trim_distance_start" value="0" type="QString"/>
+            <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+            <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+            <Option name="use_custom_dash" value="0" type="QString"/>
+            <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </profileLineSymbol>
+    <profileFillSymbol>
+      <symbol name="" force_rhr="0" alpha="1" clip_to_extent="1" type="fill" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" id="{f98dd295-11de-4683-8820-58a4e0278537}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="color" value="229,182,54,255" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="164,130,39,255" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.2" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="style" value="solid" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </profileFillSymbol>
+    <profileMarkerSymbol>
+      <symbol name="" force_rhr="0" alpha="1" clip_to_extent="1" type="marker" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" id="{5cd497de-06f2-4716-891f-54e1f9deb3b2}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="angle" value="0" type="QString"/>
+            <Option name="cap_style" value="square" type="QString"/>
+            <Option name="color" value="229,182,54,255" type="QString"/>
+            <Option name="horizontal_anchor_point" value="1" type="QString"/>
+            <Option name="joinstyle" value="bevel" type="QString"/>
+            <Option name="name" value="diamond" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="MM" type="QString"/>
+            <Option name="outline_color" value="164,130,39,255" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="0.2" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="scale_method" value="diameter" type="QString"/>
+            <Option name="size" value="3" type="QString"/>
+            <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="size_unit" value="MM" type="QString"/>
+            <Option name="vertical_anchor_point" value="1" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </profileMarkerSymbol>
+  </elevation>
+  <renderer-v2 symbollevels="0" type="RuleRenderer" enableorderby="0" referencescale="-1" forceraster="0">
+    <rules key="{63c09983-2d26-4579-ac80-dd9769b8f68f}">
+      <rule filter="&quot;ConversionCode&quot; in (41, 42, 43, 44)" symbol="0" label="Conifer Encroachment" key="{84fc2890-f3cf-4ebc-8e24-5a58ad5c7037}"/>
+      <rule filter="&quot;ConversionCode&quot; in (29, 30, 31, 32)" symbol="1" label="Conv. To Agriculture" key="{18195d90-873a-4d0b-a2c6-5e8e4ab461e7}"/>
+      <rule filter="&quot;ConversionCode&quot; in (21, 22, 23, 24)" symbol="2" label="Conv. To Grass/Shrubland" key="{6ceb3524-7a7e-4655-8e7d-8ec8607a434b}"/>
+      <rule filter="&quot;ConversionCode&quot; in (33, 34, 35, 36)" symbol="3" label="Conv. To Invasive" key="{efa7d8f6-34d0-4c9d-902b-da6c077f664d}"/>
+      <rule filter="&quot;ConversionCode&quot; in (45, 46, 47, 48)" symbol="4" label="Non-Riparian Conversions" key="{5c284893-11bc-4a05-867e-43d669e0b9a4}"/>
+      <rule filter="&quot;ConversionCode&quot; in (25, 26, 27, 28)" symbol="5" label="Devegetation" key="{2cb24909-f716-4650-a7c7-a8d6c61599c0}"/>
+      <rule filter="&quot;ConversionCode&quot; in (37, 38, 39, 40)" symbol="6" label="Development" key="{7a9ad057-6889-495f-b9b0-37ed9c1b9664}"/>
+      <rule filter="&quot;ConversionCode&quot; in (49, 50, 51, 52)" symbol="7" label="Multiple Conv. Types" key="{c693bbe9-3593-47b1-84cf-dde7048f2210}"/>
+      <rule filter="&quot;ConversionCode&quot; = 0" symbol="8" label="Negligible to Minor Veg. Conversion" key="{2431703c-a827-428f-af83-c139029ee477}"/>
+      <rule filter="&quot;ConversionCode&quot; = (9, 10, 11, 12)" symbol="9" label="From Grass/Shrubland to Riparian" key="{3a81613c-e8e8-4327-afd4-1e8d1d058e64}"/>
+      <rule filter="&quot;ConversionCode&quot; in (5, 6, 7, 8)" symbol="10" label="From Devegetated to Riparian" key="{e7a97fdf-477c-41ad-b89a-a59ca18323d3}"/>
+      <rule filter="&quot;ConversionCode&quot; in (1, 2, 3, 4)" symbol="11" label="From Conifer to Riparian" key="{5bd42e75-180b-4cb0-8e73-e7722dbddeae}"/>
+    </rules>
+    <symbols>
+      <symbol name="0" force_rhr="0" alpha="1" clip_to_extent="1" type="marker" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" id="{59ae578b-a930-497a-aaf5-99d3d5e4585a}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="angle" value="0" type="QString"/>
+            <Option name="cap_style" value="square" type="QString"/>
+            <Option name="color" value="215,70,153,255" type="QString"/>
+            <Option name="horizontal_anchor_point" value="1" type="QString"/>
+            <Option name="joinstyle" value="miter" type="QString"/>
+            <Option name="name" value="circle" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="Point" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255" type="QString"/>
+            <Option name="outline_style" value="no" type="QString"/>
+            <Option name="outline_width" value="0" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="scale_method" value="diameter" type="QString"/>
+            <Option name="size" value="3.6818" type="QString"/>
+            <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="size_unit" value="Point" type="QString"/>
+            <Option name="vertical_anchor_point" value="1" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties" type="Map">
+                <Option name="size" type="Map">
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="var('map_scale')" type="QString"/>
+                  <Option name="transformer" type="Map">
+                    <Option name="d" type="Map">
+                      <Option name="curve" type="Map">
+                        <Option name="x" value="0,0.09166666666666666,0.36666666666666664,0.82499999999999996,1" type="QString"/>
+                        <Option name="y" value="0,0.23076923076923078,0.64835164835164838,0.8571428571428571,1" type="QString"/>
+                      </Option>
+                      <Option name="exponent" value="0.57" type="double"/>
+                      <Option name="maxSize" value="1" type="double"/>
+                      <Option name="maxValue" value="100000" type="double"/>
+                      <Option name="minSize" value="10" type="double"/>
+                      <Option name="minValue" value="1" type="double"/>
+                      <Option name="nullSize" value="0" type="double"/>
+                      <Option name="scaleType" value="2" type="int"/>
+                    </Option>
+                    <Option name="t" value="1" type="int"/>
+                  </Option>
+                  <Option name="type" value="3" type="int"/>
+                </Option>
+              </Option>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="1" force_rhr="0" alpha="1" clip_to_extent="1" type="marker" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" id="{b3fa99d7-2a3a-4f06-9578-37efc1b4d7e6}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="angle" value="0" type="QString"/>
+            <Option name="cap_style" value="square" type="QString"/>
+            <Option name="color" value="229,229,21,255" type="QString"/>
+            <Option name="horizontal_anchor_point" value="1" type="QString"/>
+            <Option name="joinstyle" value="miter" type="QString"/>
+            <Option name="name" value="circle" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="Point" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255" type="QString"/>
+            <Option name="outline_style" value="no" type="QString"/>
+            <Option name="outline_width" value="0" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="scale_method" value="diameter" type="QString"/>
+            <Option name="size" value="3.6818" type="QString"/>
+            <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="size_unit" value="Point" type="QString"/>
+            <Option name="vertical_anchor_point" value="1" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties" type="Map">
+                <Option name="size" type="Map">
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="var('map_scale')" type="QString"/>
+                  <Option name="transformer" type="Map">
+                    <Option name="d" type="Map">
+                      <Option name="curve" type="Map">
+                        <Option name="x" value="0,0.09166666666666666,0.36666666666666664,0.82499999999999996,1" type="QString"/>
+                        <Option name="y" value="0,0.23076923076923078,0.64835164835164838,0.8571428571428571,1" type="QString"/>
+                      </Option>
+                      <Option name="exponent" value="0.57" type="double"/>
+                      <Option name="maxSize" value="1" type="double"/>
+                      <Option name="maxValue" value="100000" type="double"/>
+                      <Option name="minSize" value="10" type="double"/>
+                      <Option name="minValue" value="1" type="double"/>
+                      <Option name="nullSize" value="0" type="double"/>
+                      <Option name="scaleType" value="2" type="int"/>
+                    </Option>
+                    <Option name="t" value="1" type="int"/>
+                  </Option>
+                  <Option name="type" value="3" type="int"/>
+                </Option>
+              </Option>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="10" force_rhr="0" alpha="1" clip_to_extent="1" type="marker" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" id="{9be184ba-d7be-4055-bafd-2e9c86971874}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="angle" value="0" type="QString"/>
+            <Option name="cap_style" value="square" type="QString"/>
+            <Option name="color" value="31,47,231,255" type="QString"/>
+            <Option name="horizontal_anchor_point" value="1" type="QString"/>
+            <Option name="joinstyle" value="miter" type="QString"/>
+            <Option name="name" value="circle" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="Point" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255" type="QString"/>
+            <Option name="outline_style" value="no" type="QString"/>
+            <Option name="outline_width" value="0" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="scale_method" value="diameter" type="QString"/>
+            <Option name="size" value="3.6818" type="QString"/>
+            <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="size_unit" value="Point" type="QString"/>
+            <Option name="vertical_anchor_point" value="1" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties" type="Map">
+                <Option name="size" type="Map">
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="var('map_scale')" type="QString"/>
+                  <Option name="transformer" type="Map">
+                    <Option name="d" type="Map">
+                      <Option name="curve" type="Map">
+                        <Option name="x" value="0,0.09166666666666666,0.36666666666666664,0.82499999999999996,1" type="QString"/>
+                        <Option name="y" value="0,0.23076923076923078,0.64835164835164838,0.8571428571428571,1" type="QString"/>
+                      </Option>
+                      <Option name="exponent" value="0.57" type="double"/>
+                      <Option name="maxSize" value="1" type="double"/>
+                      <Option name="maxValue" value="100000" type="double"/>
+                      <Option name="minSize" value="10" type="double"/>
+                      <Option name="minValue" value="1" type="double"/>
+                      <Option name="nullSize" value="0" type="double"/>
+                      <Option name="scaleType" value="2" type="int"/>
+                    </Option>
+                    <Option name="t" value="1" type="int"/>
+                  </Option>
+                  <Option name="type" value="3" type="int"/>
+                </Option>
+              </Option>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="11" force_rhr="0" alpha="1" clip_to_extent="1" type="marker" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" id="{9be184ba-d7be-4055-bafd-2e9c86971874}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="angle" value="0" type="QString"/>
+            <Option name="cap_style" value="square" type="QString"/>
+            <Option name="color" value="147,246,170,255" type="QString"/>
+            <Option name="horizontal_anchor_point" value="1" type="QString"/>
+            <Option name="joinstyle" value="miter" type="QString"/>
+            <Option name="name" value="circle" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="Point" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255" type="QString"/>
+            <Option name="outline_style" value="no" type="QString"/>
+            <Option name="outline_width" value="0" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="scale_method" value="diameter" type="QString"/>
+            <Option name="size" value="3.6818" type="QString"/>
+            <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="size_unit" value="Point" type="QString"/>
+            <Option name="vertical_anchor_point" value="1" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties" type="Map">
+                <Option name="size" type="Map">
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="var('map_scale')" type="QString"/>
+                  <Option name="transformer" type="Map">
+                    <Option name="d" type="Map">
+                      <Option name="curve" type="Map">
+                        <Option name="x" value="0,0.09166666666666666,0.36666666666666664,0.82499999999999996,1" type="QString"/>
+                        <Option name="y" value="0,0.23076923076923078,0.64835164835164838,0.8571428571428571,1" type="QString"/>
+                      </Option>
+                      <Option name="exponent" value="0.57" type="double"/>
+                      <Option name="maxSize" value="1" type="double"/>
+                      <Option name="maxValue" value="100000" type="double"/>
+                      <Option name="minSize" value="10" type="double"/>
+                      <Option name="minValue" value="1" type="double"/>
+                      <Option name="nullSize" value="0" type="double"/>
+                      <Option name="scaleType" value="2" type="int"/>
+                    </Option>
+                    <Option name="t" value="1" type="int"/>
+                  </Option>
+                  <Option name="type" value="3" type="int"/>
+                </Option>
+              </Option>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="2" force_rhr="0" alpha="1" clip_to_extent="1" type="marker" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" id="{a177c2bc-ac46-4ef0-8302-3a2817aa346f}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="angle" value="0" type="QString"/>
+            <Option name="cap_style" value="square" type="QString"/>
+            <Option name="color" value="54,195,242,255" type="QString"/>
+            <Option name="horizontal_anchor_point" value="1" type="QString"/>
+            <Option name="joinstyle" value="miter" type="QString"/>
+            <Option name="name" value="circle" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="Point" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255" type="QString"/>
+            <Option name="outline_style" value="no" type="QString"/>
+            <Option name="outline_width" value="0" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="scale_method" value="diameter" type="QString"/>
+            <Option name="size" value="3.6818" type="QString"/>
+            <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="size_unit" value="Point" type="QString"/>
+            <Option name="vertical_anchor_point" value="1" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties" type="Map">
+                <Option name="size" type="Map">
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="var('map_scale')" type="QString"/>
+                  <Option name="transformer" type="Map">
+                    <Option name="d" type="Map">
+                      <Option name="curve" type="Map">
+                        <Option name="x" value="0,0.09166666666666666,0.36666666666666664,0.82499999999999996,1" type="QString"/>
+                        <Option name="y" value="0,0.23076923076923078,0.64835164835164838,0.8571428571428571,1" type="QString"/>
+                      </Option>
+                      <Option name="exponent" value="0.57" type="double"/>
+                      <Option name="maxSize" value="1" type="double"/>
+                      <Option name="maxValue" value="100000" type="double"/>
+                      <Option name="minSize" value="10" type="double"/>
+                      <Option name="minValue" value="1" type="double"/>
+                      <Option name="nullSize" value="0" type="double"/>
+                      <Option name="scaleType" value="2" type="int"/>
+                    </Option>
+                    <Option name="t" value="1" type="int"/>
+                  </Option>
+                  <Option name="type" value="3" type="int"/>
+                </Option>
+              </Option>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="3" force_rhr="0" alpha="1" clip_to_extent="1" type="marker" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" id="{9be184ba-d7be-4055-bafd-2e9c86971874}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="angle" value="0" type="QString"/>
+            <Option name="cap_style" value="square" type="QString"/>
+            <Option name="color" value="137,76,158,255" type="QString"/>
+            <Option name="horizontal_anchor_point" value="1" type="QString"/>
+            <Option name="joinstyle" value="miter" type="QString"/>
+            <Option name="name" value="circle" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="Point" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255" type="QString"/>
+            <Option name="outline_style" value="no" type="QString"/>
+            <Option name="outline_width" value="0" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="scale_method" value="diameter" type="QString"/>
+            <Option name="size" value="3.6818" type="QString"/>
+            <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="size_unit" value="Point" type="QString"/>
+            <Option name="vertical_anchor_point" value="1" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties" type="Map">
+                <Option name="size" type="Map">
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="var('map_scale')" type="QString"/>
+                  <Option name="transformer" type="Map">
+                    <Option name="d" type="Map">
+                      <Option name="curve" type="Map">
+                        <Option name="x" value="0,0.09166666666666666,0.36666666666666664,0.82499999999999996,1" type="QString"/>
+                        <Option name="y" value="0,0.23076923076923078,0.64835164835164838,0.8571428571428571,1" type="QString"/>
+                      </Option>
+                      <Option name="exponent" value="0.57" type="double"/>
+                      <Option name="maxSize" value="1" type="double"/>
+                      <Option name="maxValue" value="100000" type="double"/>
+                      <Option name="minSize" value="10" type="double"/>
+                      <Option name="minValue" value="1" type="double"/>
+                      <Option name="nullSize" value="0" type="double"/>
+                      <Option name="scaleType" value="2" type="int"/>
+                    </Option>
+                    <Option name="t" value="1" type="int"/>
+                  </Option>
+                  <Option name="type" value="3" type="int"/>
+                </Option>
+              </Option>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="4" force_rhr="0" alpha="1" clip_to_extent="1" type="marker" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" id="{9be184ba-d7be-4055-bafd-2e9c86971874}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="angle" value="0" type="QString"/>
+            <Option name="cap_style" value="square" type="QString"/>
+            <Option name="color" value="249,114,11,255" type="QString"/>
+            <Option name="horizontal_anchor_point" value="1" type="QString"/>
+            <Option name="joinstyle" value="miter" type="QString"/>
+            <Option name="name" value="circle" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="Point" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255" type="QString"/>
+            <Option name="outline_style" value="no" type="QString"/>
+            <Option name="outline_width" value="0" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="scale_method" value="diameter" type="QString"/>
+            <Option name="size" value="3.6818" type="QString"/>
+            <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="size_unit" value="Point" type="QString"/>
+            <Option name="vertical_anchor_point" value="1" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties" type="Map">
+                <Option name="size" type="Map">
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="var('map_scale')" type="QString"/>
+                  <Option name="transformer" type="Map">
+                    <Option name="d" type="Map">
+                      <Option name="curve" type="Map">
+                        <Option name="x" value="0,0.09166666666666666,0.36666666666666664,0.82499999999999996,1" type="QString"/>
+                        <Option name="y" value="0,0.23076923076923078,0.64835164835164838,0.8571428571428571,1" type="QString"/>
+                      </Option>
+                      <Option name="exponent" value="0.57" type="double"/>
+                      <Option name="maxSize" value="1" type="double"/>
+                      <Option name="maxValue" value="100000" type="double"/>
+                      <Option name="minSize" value="10" type="double"/>
+                      <Option name="minValue" value="1" type="double"/>
+                      <Option name="nullSize" value="0" type="double"/>
+                      <Option name="scaleType" value="2" type="int"/>
+                    </Option>
+                    <Option name="t" value="1" type="int"/>
+                  </Option>
+                  <Option name="type" value="3" type="int"/>
+                </Option>
+              </Option>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="5" force_rhr="0" alpha="1" clip_to_extent="1" type="marker" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" id="{9be184ba-d7be-4055-bafd-2e9c86971874}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="angle" value="0" type="QString"/>
+            <Option name="cap_style" value="square" type="QString"/>
+            <Option name="color" value="166,116,42,255" type="QString"/>
+            <Option name="horizontal_anchor_point" value="1" type="QString"/>
+            <Option name="joinstyle" value="miter" type="QString"/>
+            <Option name="name" value="circle" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="Point" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255" type="QString"/>
+            <Option name="outline_style" value="no" type="QString"/>
+            <Option name="outline_width" value="0" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="scale_method" value="diameter" type="QString"/>
+            <Option name="size" value="3.6818" type="QString"/>
+            <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="size_unit" value="Point" type="QString"/>
+            <Option name="vertical_anchor_point" value="1" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties" type="Map">
+                <Option name="size" type="Map">
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="var('map_scale')" type="QString"/>
+                  <Option name="transformer" type="Map">
+                    <Option name="d" type="Map">
+                      <Option name="curve" type="Map">
+                        <Option name="x" value="0,0.09166666666666666,0.36666666666666664,0.82499999999999996,1" type="QString"/>
+                        <Option name="y" value="0,0.23076923076923078,0.64835164835164838,0.8571428571428571,1" type="QString"/>
+                      </Option>
+                      <Option name="exponent" value="0.57" type="double"/>
+                      <Option name="maxSize" value="1" type="double"/>
+                      <Option name="maxValue" value="100000" type="double"/>
+                      <Option name="minSize" value="10" type="double"/>
+                      <Option name="minValue" value="1" type="double"/>
+                      <Option name="nullSize" value="0" type="double"/>
+                      <Option name="scaleType" value="2" type="int"/>
+                    </Option>
+                    <Option name="t" value="1" type="int"/>
+                  </Option>
+                  <Option name="type" value="3" type="int"/>
+                </Option>
+              </Option>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="6" force_rhr="0" alpha="1" clip_to_extent="1" type="marker" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" id="{9be184ba-d7be-4055-bafd-2e9c86971874}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="angle" value="0" type="QString"/>
+            <Option name="cap_style" value="square" type="QString"/>
+            <Option name="color" value="237,32,36,255" type="QString"/>
+            <Option name="horizontal_anchor_point" value="1" type="QString"/>
+            <Option name="joinstyle" value="miter" type="QString"/>
+            <Option name="name" value="circle" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="Point" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255" type="QString"/>
+            <Option name="outline_style" value="no" type="QString"/>
+            <Option name="outline_width" value="0" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="scale_method" value="diameter" type="QString"/>
+            <Option name="size" value="3.6818" type="QString"/>
+            <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="size_unit" value="Point" type="QString"/>
+            <Option name="vertical_anchor_point" value="1" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties" type="Map">
+                <Option name="size" type="Map">
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="var('map_scale')" type="QString"/>
+                  <Option name="transformer" type="Map">
+                    <Option name="d" type="Map">
+                      <Option name="curve" type="Map">
+                        <Option name="x" value="0,0.09166666666666666,0.36666666666666664,0.82499999999999996,1" type="QString"/>
+                        <Option name="y" value="0,0.23076923076923078,0.64835164835164838,0.8571428571428571,1" type="QString"/>
+                      </Option>
+                      <Option name="exponent" value="0.57" type="double"/>
+                      <Option name="maxSize" value="1" type="double"/>
+                      <Option name="maxValue" value="100000" type="double"/>
+                      <Option name="minSize" value="10" type="double"/>
+                      <Option name="minValue" value="1" type="double"/>
+                      <Option name="nullSize" value="0" type="double"/>
+                      <Option name="scaleType" value="2" type="int"/>
+                    </Option>
+                    <Option name="t" value="1" type="int"/>
+                  </Option>
+                  <Option name="type" value="3" type="int"/>
+                </Option>
+              </Option>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="7" force_rhr="0" alpha="1" clip_to_extent="1" type="marker" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" id="{9be184ba-d7be-4055-bafd-2e9c86971874}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="angle" value="0" type="QString"/>
+            <Option name="cap_style" value="square" type="QString"/>
+            <Option name="color" value="79,79,79,255" type="QString"/>
+            <Option name="horizontal_anchor_point" value="1" type="QString"/>
+            <Option name="joinstyle" value="miter" type="QString"/>
+            <Option name="name" value="circle" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="Point" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255" type="QString"/>
+            <Option name="outline_style" value="no" type="QString"/>
+            <Option name="outline_width" value="0" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="scale_method" value="diameter" type="QString"/>
+            <Option name="size" value="3.6818" type="QString"/>
+            <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="size_unit" value="Point" type="QString"/>
+            <Option name="vertical_anchor_point" value="1" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties" type="Map">
+                <Option name="size" type="Map">
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="var('map_scale')" type="QString"/>
+                  <Option name="transformer" type="Map">
+                    <Option name="d" type="Map">
+                      <Option name="curve" type="Map">
+                        <Option name="x" value="0,0.09166666666666666,0.36666666666666664,0.82499999999999996,1" type="QString"/>
+                        <Option name="y" value="0,0.23076923076923078,0.64835164835164838,0.8571428571428571,1" type="QString"/>
+                      </Option>
+                      <Option name="exponent" value="0.57" type="double"/>
+                      <Option name="maxSize" value="1" type="double"/>
+                      <Option name="maxValue" value="100000" type="double"/>
+                      <Option name="minSize" value="10" type="double"/>
+                      <Option name="minValue" value="1" type="double"/>
+                      <Option name="nullSize" value="0" type="double"/>
+                      <Option name="scaleType" value="2" type="int"/>
+                    </Option>
+                    <Option name="t" value="1" type="int"/>
+                  </Option>
+                  <Option name="type" value="3" type="int"/>
+                </Option>
+              </Option>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="8" force_rhr="0" alpha="1" clip_to_extent="1" type="marker" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" id="{9be184ba-d7be-4055-bafd-2e9c86971874}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="angle" value="0" type="QString"/>
+            <Option name="cap_style" value="square" type="QString"/>
+            <Option name="color" value="109,190,69,255" type="QString"/>
+            <Option name="horizontal_anchor_point" value="1" type="QString"/>
+            <Option name="joinstyle" value="miter" type="QString"/>
+            <Option name="name" value="circle" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="Point" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255" type="QString"/>
+            <Option name="outline_style" value="no" type="QString"/>
+            <Option name="outline_width" value="0" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="scale_method" value="diameter" type="QString"/>
+            <Option name="size" value="3.6818" type="QString"/>
+            <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="size_unit" value="Point" type="QString"/>
+            <Option name="vertical_anchor_point" value="1" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties" type="Map">
+                <Option name="size" type="Map">
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="var('map_scale')" type="QString"/>
+                  <Option name="transformer" type="Map">
+                    <Option name="d" type="Map">
+                      <Option name="curve" type="Map">
+                        <Option name="x" value="0,0.09166666666666666,0.36666666666666664,0.82499999999999996,1" type="QString"/>
+                        <Option name="y" value="0,0.23076923076923078,0.64835164835164838,0.8571428571428571,1" type="QString"/>
+                      </Option>
+                      <Option name="exponent" value="0.57" type="double"/>
+                      <Option name="maxSize" value="1" type="double"/>
+                      <Option name="maxValue" value="100000" type="double"/>
+                      <Option name="minSize" value="10" type="double"/>
+                      <Option name="minValue" value="1" type="double"/>
+                      <Option name="nullSize" value="0" type="double"/>
+                      <Option name="scaleType" value="2" type="int"/>
+                    </Option>
+                    <Option name="t" value="1" type="int"/>
+                  </Option>
+                  <Option name="type" value="3" type="int"/>
+                </Option>
+              </Option>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol name="9" force_rhr="0" alpha="1" clip_to_extent="1" type="marker" is_animated="0" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" id="{9be184ba-d7be-4055-bafd-2e9c86971874}" pass="0" locked="0" enabled="1">
+          <Option type="Map">
+            <Option name="angle" value="0" type="QString"/>
+            <Option name="cap_style" value="square" type="QString"/>
+            <Option name="color" value="31,218,231,255" type="QString"/>
+            <Option name="horizontal_anchor_point" value="1" type="QString"/>
+            <Option name="joinstyle" value="miter" type="QString"/>
+            <Option name="name" value="circle" type="QString"/>
+            <Option name="offset" value="0,0" type="QString"/>
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="Point" type="QString"/>
+            <Option name="outline_color" value="35,35,35,255" type="QString"/>
+            <Option name="outline_style" value="no" type="QString"/>
+            <Option name="outline_width" value="0" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="MM" type="QString"/>
+            <Option name="scale_method" value="diameter" type="QString"/>
+            <Option name="size" value="3.6818" type="QString"/>
+            <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="size_unit" value="Point" type="QString"/>
+            <Option name="vertical_anchor_point" value="1" type="QString"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties" type="Map">
+                <Option name="size" type="Map">
+                  <Option name="active" value="true" type="bool"/>
+                  <Option name="expression" value="var('map_scale')" type="QString"/>
+                  <Option name="transformer" type="Map">
+                    <Option name="d" type="Map">
+                      <Option name="curve" type="Map">
+                        <Option name="x" value="0,0.09166666666666666,0.36666666666666664,0.82499999999999996,1" type="QString"/>
+                        <Option name="y" value="0,0.23076923076923078,0.64835164835164838,0.8571428571428571,1" type="QString"/>
+                      </Option>
+                      <Option name="exponent" value="0.57" type="double"/>
+                      <Option name="maxSize" value="1" type="double"/>
+                      <Option name="maxValue" value="100000" type="double"/>
+                      <Option name="minSize" value="10" type="double"/>
+                      <Option name="minValue" value="1" type="double"/>
+                      <Option name="nullSize" value="0" type="double"/>
+                      <Option name="scaleType" value="2" type="int"/>
+                    </Option>
+                    <Option name="t" value="1" type="int"/>
+                  </Option>
+                  <Option name="type" value="3" type="int"/>
+                </Option>
+              </Option>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style forcedItalic="0" multilineHeight="1" fontWordSpacing="0" forcedBold="0" fieldName="&quot;ConversionType&quot;" fontSizeMapUnitScale="3x:0,0,0,0,0,0" textOrientation="horizontal" fontUnderline="0" capitalization="0" fontKerning="1" isExpression="1" fontSize="8" allowHtml="0" textColor="0,0,0,255" useSubstitutions="0" blendMode="0" fontItalic="0" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" fontSizeUnit="Point" multilineHeightUnit="Percentage" fontWeight="16" fontFamily="Arial" namedStyle="" previewBkgrdColor="255,255,255,255" textOpacity="1">
+        <families/>
+        <text-buffer bufferDraw="0" bufferSizeUnits="Point" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferNoFill="1" bufferJoinStyle="128" bufferColor="255,255,255,255" bufferSize="2" bufferOpacity="1"/>
+        <text-mask maskSize="1.5" maskOpacity="1" maskEnabled="0" maskSizeUnits="MM" maskJoinStyle="128" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskedSymbolLayers="" maskType="0"/>
+        <background shapeRotation="0" shapeBorderWidthUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeType="0" shapeRadiiY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeSizeX="0" shapeFillColor="255,255,255,255" shapeSizeY="0" shapeJoinStyle="64" shapeRadiiUnit="MM" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeBorderColor="128,128,128,255" shapeSizeUnit="MM" shapeBorderWidth="0" shapeSizeType="0" shapeOffsetY="0" shapeBlendMode="0" shapeSVGFile="" shapeOffsetX="0" shapeOffsetUnit="MM" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeDraw="0" shapeOpacity="1">
+          <symbol name="fillSymbol" force_rhr="0" alpha="1" clip_to_extent="1" type="fill" is_animated="0" frame_rate="10">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer class="SimpleFill" id="" pass="0" locked="0" enabled="1">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color" value="255,255,255,255" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="128,128,128,255" type="QString"/>
+                <Option name="outline_style" value="no" type="QString"/>
+                <Option name="outline_width" value="0" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="style" value="solid" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowRadiusUnit="MM" shadowOffsetUnit="MM" shadowBlendMode="6" shadowDraw="0" shadowRadiusAlphaOnly="0" shadowOffsetAngle="135" shadowOpacity="0.69999999999999996" shadowOffsetGlobal="1" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadius="1.5"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </dd_properties>
+        <substitutions/>
+      </text-style>
+      <text-format rightDirectionSymbol=">" formatNumbers="0" autoWrapLength="0" addDirectionSymbol="0" leftDirectionSymbol="&lt;" decimals="3" useMaxLineLengthForAutoWrap="1" multilineAlign="1" placeDirectionSymbol="0" wrapChar="" plussign="0" reverseDirectionSymbol="0"/>
+      <placement labelOffsetMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" centroidWhole="0" overrunDistanceUnit="MM" overrunDistance="0" maxCurvedCharAngleIn="25" lineAnchorType="0" repeatDistanceUnits="MM" layerType="UnknownGeometry" maxCurvedCharAngleOut="-25" fitInPolygonOnly="0" geometryGeneratorEnabled="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" dist="0" centroidInside="0" distUnits="Point" overlapHandling="PreventOverlap" polygonPlacementFlags="2" rotationAngle="0" placement="6" yOffset="0" lineAnchorTextPoint="FollowPlacement" offsetType="1" allowDegraded="0" placementFlags="10" lineAnchorPercent="0.5" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" lineAnchorClipping="0" repeatDistance="0" offsetUnits="MM" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" rotationUnit="AngleDegrees" priority="10" distMapUnitScale="3x:0,0,0,0,0,0" quadOffset="4" geometryGenerator=""/>
+      <rendering obstacle="0" fontMaxPixelSize="10000" mergeLines="0" scaleMin="0" unplacedVisibility="0" fontMinPixelSize="0" zIndex="0" limitNumLabels="0" minFeatureSize="0" upsidedownLabels="0" fontLimitPixelSize="0" labelPerPart="0" obstacleType="1" drawLabels="1" scaleVisibility="0" scaleMax="0" maxNumLabels="2000" obstacleFactor="0"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option name="name" value="" type="QString"/>
+          <Option name="properties" type="Map">
+            <Option name="PredefinedPositionOrder" type="Map">
+              <Option name="active" value="true" type="bool"/>
+              <Option name="expression" value="'TR,TL,BR,R,T,BL,L,B'" type="QString"/>
+              <Option name="type" value="3" type="int"/>
+            </Option>
+          </Option>
+          <Option name="type" value="collection" type="QString"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option name="anchorPoint" value="pole_of_inaccessibility" type="QString"/>
+          <Option name="blendMode" value="0" type="int"/>
+          <Option name="ddProperties" type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+          <Option name="drawToAllParts" value="false" type="bool"/>
+          <Option name="enabled" value="0" type="QString"/>
+          <Option name="labelAnchorPoint" value="point_on_exterior" type="QString"/>
+          <Option name="lineSymbol" value="&lt;symbol name=&quot;symbol&quot; force_rhr=&quot;0&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; type=&quot;line&quot; is_animated=&quot;0&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; id=&quot;{8ea22308-31d8-4912-a316-a692abc5b1de}&quot; pass=&quot;0&quot; locked=&quot;0&quot; enabled=&quot;1&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;capstyle&quot; value=&quot;square&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash&quot; value=&quot;5;2&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;customdash_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;joinstyle&quot; value=&quot;bevel&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_color&quot; value=&quot;60,60,60,255&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_style&quot; value=&quot;solid&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width&quot; value=&quot;0.3&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;line_width_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;offset_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;ring_filter&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; value=&quot;MM&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;use_custom_dash&quot; value=&quot;0&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; value=&quot;&quot; type=&quot;QString&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; value=&quot;collection&quot; type=&quot;QString&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString"/>
+          <Option name="minLength" value="0" type="double"/>
+          <Option name="minLengthMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="minLengthUnit" value="MM" type="QString"/>
+          <Option name="offsetFromAnchor" value="0" type="double"/>
+          <Option name="offsetFromAnchorMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromAnchorUnit" value="MM" type="QString"/>
+          <Option name="offsetFromLabel" value="0" type="double"/>
+          <Option name="offsetFromLabelMapUnitScale" value="3x:0,0,0,0,0,0" type="QString"/>
+          <Option name="offsetFromLabelUnit" value="MM" type="QString"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
+  <customproperties>
+    <Option type="Map">
+      <Option name="embeddedWidgets/count" value="0" type="int"/>
+      <Option name="variableNames"/>
+      <Option name="variableValues"/>
+    </Option>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+    <DiagramCategory enabled="0" lineSizeType="MM" sizeType="MM" spacing="5" penWidth="0" opacity="1" rotationOffset="270" diagramOrientation="Up" maxScaleDenominator="0" penAlpha="255" lineSizeScale="3x:0,0,0,0,0,0" backgroundColor="#ffffff" showAxis="1" backgroundAlpha="255" spacingUnit="MM" barWidth="5" scaleDependency="Area" width="15" sizeScale="3x:0,0,0,0,0,0" penColor="#000000" direction="0" labelPlacementMethod="XHeight" spacingUnitScale="3x:0,0,0,0,0,0" height="15" scaleBasedVisibility="0" minScaleDenominator="0" minimumSize="0">
+      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" bold="0" italic="0" underline="0" strikethrough="0" style=""/>
+      <attribute color="#000000" colorOpacity="1" field="" label=""/>
+      <axisSymbol>
+        <symbol name="" force_rhr="0" alpha="1" clip_to_extent="1" type="line" is_animated="0" frame_rate="10">
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+          <layer class="SimpleLine" id="{fa4e45e1-2cf0-4701-9f6f-d480cb41918c}" pass="0" locked="0" enabled="1">
+            <Option type="Map">
+              <Option name="align_dash_pattern" value="0" type="QString"/>
+              <Option name="capstyle" value="square" type="QString"/>
+              <Option name="customdash" value="5;2" type="QString"/>
+              <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="customdash_unit" value="MM" type="QString"/>
+              <Option name="dash_pattern_offset" value="0" type="QString"/>
+              <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+              <Option name="draw_inside_polygon" value="0" type="QString"/>
+              <Option name="joinstyle" value="bevel" type="QString"/>
+              <Option name="line_color" value="35,35,35,255" type="QString"/>
+              <Option name="line_style" value="solid" type="QString"/>
+              <Option name="line_width" value="0.26" type="QString"/>
+              <Option name="line_width_unit" value="MM" type="QString"/>
+              <Option name="offset" value="0" type="QString"/>
+              <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="offset_unit" value="MM" type="QString"/>
+              <Option name="ring_filter" value="0" type="QString"/>
+              <Option name="trim_distance_end" value="0" type="QString"/>
+              <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+              <Option name="trim_distance_start" value="0" type="QString"/>
+              <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+              <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+              <Option name="use_custom_dash" value="0" type="QString"/>
+              <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            </Option>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </axisSymbol>
+    </DiagramCategory>
+  </SingleCategoryDiagramRenderer>
+  <DiagramLayerSettings obstacle="0" showAll="1" priority="0" zIndex="0" dist="0" placement="0" linePlacementFlags="18">
+    <properties>
+      <Option type="Map">
+        <Option name="name" value="" type="QString"/>
+        <Option name="properties"/>
+        <Option name="type" value="collection" type="QString"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <legend showLabelLegend="0" type="default-vector"/>
+  <referencedLayers/>
+  <fieldConfiguration>
+    <field configurationFlags="None" name="IGOID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="LevelPathI">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="seg_distance">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="stream_size">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="LUI">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="FloodplainAccess">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="FromConifer">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="FromDevegetated">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="FromGrassShrubland">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="NoChange">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="GrassShrubland">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="Devegetation">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="Conifer">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="Invasive">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="Development">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="Agriculture">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="NonRiparian">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="ConversionID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="LevelID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="ExistingRiparianMean">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="HistoricRiparianMean">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="RiparianDeparture">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="RiparianDepartureID">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="Condition">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="ConversionCode">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="ConversionType">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="None" name="Departure">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias index="0" field="IGOID" name=""/>
+    <alias index="1" field="LevelPathI" name=""/>
+    <alias index="2" field="seg_distance" name=""/>
+    <alias index="3" field="stream_size" name=""/>
+    <alias index="4" field="LUI" name=""/>
+    <alias index="5" field="FloodplainAccess" name=""/>
+    <alias index="6" field="FromConifer" name=""/>
+    <alias index="7" field="FromDevegetated" name=""/>
+    <alias index="8" field="FromGrassShrubland" name=""/>
+    <alias index="9" field="NoChange" name=""/>
+    <alias index="10" field="GrassShrubland" name=""/>
+    <alias index="11" field="Devegetation" name=""/>
+    <alias index="12" field="Conifer" name=""/>
+    <alias index="13" field="Invasive" name=""/>
+    <alias index="14" field="Development" name=""/>
+    <alias index="15" field="Agriculture" name=""/>
+    <alias index="16" field="NonRiparian" name=""/>
+    <alias index="17" field="ConversionID" name=""/>
+    <alias index="18" field="LevelID" name=""/>
+    <alias index="19" field="ExistingRiparianMean" name=""/>
+    <alias index="20" field="HistoricRiparianMean" name=""/>
+    <alias index="21" field="RiparianDeparture" name=""/>
+    <alias index="22" field="RiparianDepartureID" name=""/>
+    <alias index="23" field="Condition" name=""/>
+    <alias index="24" field="ConversionCode" name=""/>
+    <alias index="25" field="ConversionType" name=""/>
+    <alias index="26" field="Departure" name=""/>
+  </aliases>
+  <splitPolicies>
+    <policy field="IGOID" policy="Duplicate"/>
+    <policy field="LevelPathI" policy="Duplicate"/>
+    <policy field="seg_distance" policy="Duplicate"/>
+    <policy field="stream_size" policy="Duplicate"/>
+    <policy field="LUI" policy="Duplicate"/>
+    <policy field="FloodplainAccess" policy="Duplicate"/>
+    <policy field="FromConifer" policy="Duplicate"/>
+    <policy field="FromDevegetated" policy="Duplicate"/>
+    <policy field="FromGrassShrubland" policy="Duplicate"/>
+    <policy field="NoChange" policy="Duplicate"/>
+    <policy field="GrassShrubland" policy="Duplicate"/>
+    <policy field="Devegetation" policy="Duplicate"/>
+    <policy field="Conifer" policy="Duplicate"/>
+    <policy field="Invasive" policy="Duplicate"/>
+    <policy field="Development" policy="Duplicate"/>
+    <policy field="Agriculture" policy="Duplicate"/>
+    <policy field="NonRiparian" policy="Duplicate"/>
+    <policy field="ConversionID" policy="Duplicate"/>
+    <policy field="LevelID" policy="Duplicate"/>
+    <policy field="ExistingRiparianMean" policy="Duplicate"/>
+    <policy field="HistoricRiparianMean" policy="Duplicate"/>
+    <policy field="RiparianDeparture" policy="Duplicate"/>
+    <policy field="RiparianDepartureID" policy="Duplicate"/>
+    <policy field="Condition" policy="Duplicate"/>
+    <policy field="ConversionCode" policy="Duplicate"/>
+    <policy field="ConversionType" policy="Duplicate"/>
+    <policy field="Departure" policy="Duplicate"/>
+  </splitPolicies>
+  <defaults>
+    <default applyOnUpdate="0" field="IGOID" expression=""/>
+    <default applyOnUpdate="0" field="LevelPathI" expression=""/>
+    <default applyOnUpdate="0" field="seg_distance" expression=""/>
+    <default applyOnUpdate="0" field="stream_size" expression=""/>
+    <default applyOnUpdate="0" field="LUI" expression=""/>
+    <default applyOnUpdate="0" field="FloodplainAccess" expression=""/>
+    <default applyOnUpdate="0" field="FromConifer" expression=""/>
+    <default applyOnUpdate="0" field="FromDevegetated" expression=""/>
+    <default applyOnUpdate="0" field="FromGrassShrubland" expression=""/>
+    <default applyOnUpdate="0" field="NoChange" expression=""/>
+    <default applyOnUpdate="0" field="GrassShrubland" expression=""/>
+    <default applyOnUpdate="0" field="Devegetation" expression=""/>
+    <default applyOnUpdate="0" field="Conifer" expression=""/>
+    <default applyOnUpdate="0" field="Invasive" expression=""/>
+    <default applyOnUpdate="0" field="Development" expression=""/>
+    <default applyOnUpdate="0" field="Agriculture" expression=""/>
+    <default applyOnUpdate="0" field="NonRiparian" expression=""/>
+    <default applyOnUpdate="0" field="ConversionID" expression=""/>
+    <default applyOnUpdate="0" field="LevelID" expression=""/>
+    <default applyOnUpdate="0" field="ExistingRiparianMean" expression=""/>
+    <default applyOnUpdate="0" field="HistoricRiparianMean" expression=""/>
+    <default applyOnUpdate="0" field="RiparianDeparture" expression=""/>
+    <default applyOnUpdate="0" field="RiparianDepartureID" expression=""/>
+    <default applyOnUpdate="0" field="Condition" expression=""/>
+    <default applyOnUpdate="0" field="ConversionCode" expression=""/>
+    <default applyOnUpdate="0" field="ConversionType" expression=""/>
+    <default applyOnUpdate="0" field="Departure" expression=""/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="1" field="IGOID" notnull_strength="1" exp_strength="0" constraints="3"/>
+    <constraint unique_strength="0" field="LevelPathI" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="seg_distance" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="stream_size" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="LUI" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="FloodplainAccess" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="FromConifer" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="FromDevegetated" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="FromGrassShrubland" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="NoChange" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="GrassShrubland" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="Devegetation" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="Conifer" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="Invasive" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="Development" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="Agriculture" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="NonRiparian" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="ConversionID" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="LevelID" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="ExistingRiparianMean" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="HistoricRiparianMean" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="RiparianDeparture" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="RiparianDepartureID" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="Condition" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="ConversionCode" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="ConversionType" notnull_strength="0" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="Departure" notnull_strength="0" exp_strength="0" constraints="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint field="IGOID" exp="" desc=""/>
+    <constraint field="LevelPathI" exp="" desc=""/>
+    <constraint field="seg_distance" exp="" desc=""/>
+    <constraint field="stream_size" exp="" desc=""/>
+    <constraint field="LUI" exp="" desc=""/>
+    <constraint field="FloodplainAccess" exp="" desc=""/>
+    <constraint field="FromConifer" exp="" desc=""/>
+    <constraint field="FromDevegetated" exp="" desc=""/>
+    <constraint field="FromGrassShrubland" exp="" desc=""/>
+    <constraint field="NoChange" exp="" desc=""/>
+    <constraint field="GrassShrubland" exp="" desc=""/>
+    <constraint field="Devegetation" exp="" desc=""/>
+    <constraint field="Conifer" exp="" desc=""/>
+    <constraint field="Invasive" exp="" desc=""/>
+    <constraint field="Development" exp="" desc=""/>
+    <constraint field="Agriculture" exp="" desc=""/>
+    <constraint field="NonRiparian" exp="" desc=""/>
+    <constraint field="ConversionID" exp="" desc=""/>
+    <constraint field="LevelID" exp="" desc=""/>
+    <constraint field="ExistingRiparianMean" exp="" desc=""/>
+    <constraint field="HistoricRiparianMean" exp="" desc=""/>
+    <constraint field="RiparianDeparture" exp="" desc=""/>
+    <constraint field="RiparianDepartureID" exp="" desc=""/>
+    <constraint field="Condition" exp="" desc=""/>
+    <constraint field="ConversionCode" exp="" desc=""/>
+    <constraint field="ConversionType" exp="" desc=""/>
+    <constraint field="Departure" exp="" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+    <columns>
+      <column width="-1" name="IGOID" type="field" hidden="0"/>
+      <column width="-1" name="LevelPathI" type="field" hidden="0"/>
+      <column width="-1" name="seg_distance" type="field" hidden="0"/>
+      <column width="-1" name="stream_size" type="field" hidden="0"/>
+      <column width="-1" name="LUI" type="field" hidden="0"/>
+      <column width="-1" name="FloodplainAccess" type="field" hidden="0"/>
+      <column width="-1" name="FromConifer" type="field" hidden="0"/>
+      <column width="-1" name="FromDevegetated" type="field" hidden="0"/>
+      <column width="-1" name="FromGrassShrubland" type="field" hidden="0"/>
+      <column width="-1" name="NoChange" type="field" hidden="0"/>
+      <column width="-1" name="GrassShrubland" type="field" hidden="0"/>
+      <column width="-1" name="Devegetation" type="field" hidden="0"/>
+      <column width="-1" name="Conifer" type="field" hidden="0"/>
+      <column width="-1" name="Invasive" type="field" hidden="0"/>
+      <column width="-1" name="Development" type="field" hidden="0"/>
+      <column width="-1" name="Agriculture" type="field" hidden="0"/>
+      <column width="-1" name="ConversionID" type="field" hidden="0"/>
+      <column width="-1" name="LevelID" type="field" hidden="0"/>
+      <column width="-1" name="ExistingRiparianMean" type="field" hidden="0"/>
+      <column width="-1" name="HistoricRiparianMean" type="field" hidden="0"/>
+      <column width="-1" name="RiparianDeparture" type="field" hidden="0"/>
+      <column width="-1" name="RiparianDepartureID" type="field" hidden="0"/>
+      <column width="-1" name="Condition" type="field" hidden="0"/>
+      <column width="-1" name="ConversionCode" type="field" hidden="0"/>
+      <column width="-1" name="ConversionType" type="field" hidden="0"/>
+      <column width="-1" name="Departure" type="field" hidden="0"/>
+      <column width="-1" name="NonRiparian" type="field" hidden="0"/>
+      <column width="-1" type="actions" hidden="1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <storedexpressions/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>generatedlayout</editorlayout>
+  <editable>
+    <field name="Agriculture" editable="1"/>
+    <field name="Condition" editable="1"/>
+    <field name="Conifer" editable="1"/>
+    <field name="ConversionCode" editable="1"/>
+    <field name="ConversionID" editable="1"/>
+    <field name="ConversionType" editable="1"/>
+    <field name="Deciduous" editable="1"/>
+    <field name="Departure" editable="1"/>
+    <field name="Devegetation" editable="1"/>
+    <field name="Development" editable="1"/>
+    <field name="ExistingNativeRiparianMean" editable="1"/>
+    <field name="ExistingRiparianMean" editable="1"/>
+    <field name="FloodplainAccess" editable="1"/>
+    <field name="FromConifer" editable="1"/>
+    <field name="FromDeciduous" editable="1"/>
+    <field name="FromDevegetated" editable="1"/>
+    <field name="FromGrassShrubland" editable="1"/>
+    <field name="GrassShrubland" editable="1"/>
+    <field name="HistoricNativeRiparianMean" editable="1"/>
+    <field name="HistoricRiparianMean" editable="1"/>
+    <field name="IGOID" editable="1"/>
+    <field name="Invasive" editable="1"/>
+    <field name="LUI" editable="1"/>
+    <field name="LevelID" editable="1"/>
+    <field name="LevelPathI" editable="1"/>
+    <field name="NativeRiparianDeparture" editable="1"/>
+    <field name="NoChange" editable="1"/>
+    <field name="NonRiparian" editable="1"/>
+    <field name="RiparianDeparture" editable="1"/>
+    <field name="RiparianDepartureID" editable="1"/>
+    <field name="RiparianTotal" editable="1"/>
+    <field name="seg_distance" editable="1"/>
+    <field name="stream_size" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="Agriculture" labelOnTop="0"/>
+    <field name="Condition" labelOnTop="0"/>
+    <field name="Conifer" labelOnTop="0"/>
+    <field name="ConversionCode" labelOnTop="0"/>
+    <field name="ConversionID" labelOnTop="0"/>
+    <field name="ConversionType" labelOnTop="0"/>
+    <field name="Deciduous" labelOnTop="0"/>
+    <field name="Departure" labelOnTop="0"/>
+    <field name="Devegetation" labelOnTop="0"/>
+    <field name="Development" labelOnTop="0"/>
+    <field name="ExistingNativeRiparianMean" labelOnTop="0"/>
+    <field name="ExistingRiparianMean" labelOnTop="0"/>
+    <field name="FloodplainAccess" labelOnTop="0"/>
+    <field name="FromConifer" labelOnTop="0"/>
+    <field name="FromDeciduous" labelOnTop="0"/>
+    <field name="FromDevegetated" labelOnTop="0"/>
+    <field name="FromGrassShrubland" labelOnTop="0"/>
+    <field name="GrassShrubland" labelOnTop="0"/>
+    <field name="HistoricNativeRiparianMean" labelOnTop="0"/>
+    <field name="HistoricRiparianMean" labelOnTop="0"/>
+    <field name="IGOID" labelOnTop="0"/>
+    <field name="Invasive" labelOnTop="0"/>
+    <field name="LUI" labelOnTop="0"/>
+    <field name="LevelID" labelOnTop="0"/>
+    <field name="LevelPathI" labelOnTop="0"/>
+    <field name="NativeRiparianDeparture" labelOnTop="0"/>
+    <field name="NoChange" labelOnTop="0"/>
+    <field name="NonRiparian" labelOnTop="0"/>
+    <field name="RiparianDeparture" labelOnTop="0"/>
+    <field name="RiparianDepartureID" labelOnTop="0"/>
+    <field name="RiparianTotal" labelOnTop="0"/>
+    <field name="seg_distance" labelOnTop="0"/>
+    <field name="stream_size" labelOnTop="0"/>
+  </labelOnTop>
+  <reuseLastValue>
+    <field reuseLastValue="0" name="Agriculture"/>
+    <field reuseLastValue="0" name="Condition"/>
+    <field reuseLastValue="0" name="Conifer"/>
+    <field reuseLastValue="0" name="ConversionCode"/>
+    <field reuseLastValue="0" name="ConversionID"/>
+    <field reuseLastValue="0" name="ConversionType"/>
+    <field reuseLastValue="0" name="Deciduous"/>
+    <field reuseLastValue="0" name="Departure"/>
+    <field reuseLastValue="0" name="Devegetation"/>
+    <field reuseLastValue="0" name="Development"/>
+    <field reuseLastValue="0" name="ExistingNativeRiparianMean"/>
+    <field reuseLastValue="0" name="ExistingRiparianMean"/>
+    <field reuseLastValue="0" name="FloodplainAccess"/>
+    <field reuseLastValue="0" name="FromConifer"/>
+    <field reuseLastValue="0" name="FromDeciduous"/>
+    <field reuseLastValue="0" name="FromDevegetated"/>
+    <field reuseLastValue="0" name="FromGrassShrubland"/>
+    <field reuseLastValue="0" name="GrassShrubland"/>
+    <field reuseLastValue="0" name="HistoricNativeRiparianMean"/>
+    <field reuseLastValue="0" name="HistoricRiparianMean"/>
+    <field reuseLastValue="0" name="IGOID"/>
+    <field reuseLastValue="0" name="Invasive"/>
+    <field reuseLastValue="0" name="LUI"/>
+    <field reuseLastValue="0" name="LevelID"/>
+    <field reuseLastValue="0" name="LevelPathI"/>
+    <field reuseLastValue="0" name="NativeRiparianDeparture"/>
+    <field reuseLastValue="0" name="NoChange"/>
+    <field reuseLastValue="0" name="NonRiparian"/>
+    <field reuseLastValue="0" name="RiparianDeparture"/>
+    <field reuseLastValue="0" name="RiparianDepartureID"/>
+    <field reuseLastValue="0" name="RiparianTotal"/>
+    <field reuseLastValue="0" name="seg_distance"/>
+    <field reuseLastValue="0" name="stream_size"/>
+  </reuseLastValue>
+  <dataDefinedFieldProperties/>
+  <widgets/>
+  <previewExpression>"ConversionType"</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>0</layerGeometryType>
+</qgis>


### PR DESCRIPTION
New symbology for <ConversionCode> and adding adding <ConversionCode> to the business logic under igo, reach & raster intermediates. 

This pull request will also change the raster in the default RCAT view from the DEM to a hillshade, so it might be better to wait to merge with master until the hillshades are tiled for WebRAVE? 

Images of symbology & legend for igo, reaches & raster. I tested using RCAT for Wakarusa River-Clinton Lake HUC: 1027010401 v 3.1.1. 
![image](https://github.com/Riverscapes/RiverscapesXML/assets/106760640/baf8f54e-3fbe-4e81-be7f-b2cedaa6ecf2)
![image](https://github.com/Riverscapes/RiverscapesXML/assets/106760640/fa088894-76d1-4141-b8f7-da0eebcbb73d)
![image](https://github.com/Riverscapes/RiverscapesXML/assets/106760640/39f746e2-0966-44ea-bd7d-369afa0997da)



