### PR TITLE
Attempting to fix DCE repeaters

### DIFF
--- a/RaveBusinessLogic/V2/Inundation.xml
+++ b/RaveBusinessLogic/V2/Inundation.xml
@@ -6,7 +6,7 @@
     <Children>
       <Node label="Mapping" id="mapping">
         <Children>
-          <Repeater label="DCEs" xpath="Realizations/InundationDCE">
+          <Repeater label="DCEs" xpath="Realizations/Realization[@id[starts-with(., 'DCE_')]]">
             <Node xpathlabel="Name">
               <Children>
                 <Node label="Channels">


### PR DESCRIPTION
@joewheaton this change attempts to make DCE repeaters work for RIM projects per my comments in #873 

I confess that I downloaded two projects and have no knowledge about the consistency of how Karen structure these data and whether this fix will work for all RIM projects.

Karen used some very non-standard ways to structure here project.rs.xml files. She reused `Realizations` for different purposes (e.g. DCE and riverscapes), making it hard to tease out the business logic.

If you accept this pull request, then you should immediately go test a bunch of different projects. My spidey senses tell me that Karen's strategy for project.rs.xml might have evolved over time and there will be inconsistency, making this fix not work for some of the projects.