### PR TITLE
include attachments for qris projects

### DIFF
--- a/RaveBusinessLogic/V2/RiverscapesStudio.xml
+++ b/RaveBusinessLogic/V2/RiverscapesStudio.xml
@@ -160,6 +160,13 @@
                     </Children> -->
                 </Node>
             </Repeater>
+            <Node label="Attachments" xpath="Realizations/Realization[@id='attachments']" id="attachments">
+                <Children collapsed="true">
+                    <Repeater label="Files" xpath="Datasets/File">
+                        <Node xpathlabel="Name" type="file"/>
+                    </Repeater>
+                </Children>
+            </Node>
         </Children>
       </Node>
     <Views default="DEFAULT">


### PR DESCRIPTION
Adds the Attachments node.
<img width="222" height="234" alt="image" src="https://github.com/user-attachments/assets/7fd56d7d-b5fc-4611-b5d7-049193bb7d89" />

I can't figure out how to do this without including a redundant "Files" repeater node, but this is fine for now.