### PR TITLE
Web NHD flowlines fix, closes issue #1000

### DIFF
--- a/Symbology/web/Shared/flow_lines.json
+++ b/Symbology/web/Shared/flow_lines.json
@@ -19,7 +19,7 @@
       "paint": {
           "line-color": [
               "match",
-              ["get", "fcode"],
+              ["get", "FCode"],
               [46006],
               "hsl(213, 100%, 33%)",
               [33400],
@@ -39,7 +39,7 @@
       "paint": {
           "line-color": [
               "match",
-              ["get", "fcode"],
+              ["get", "FCode"],
               [46003],
               "hsl(80, 100%, 50%)",
               [46007],
@@ -61,7 +61,7 @@
           "line-dasharray": [2, 2],
           "line-color": [
               "match",
-              ["get", "fcode"],
+              ["get", "FCode"],
               [
                 42800,
                 42801,
@@ -96,7 +96,7 @@
       "paint": {
           "line-color": [
               "match",
-              ["get", "fcode"],
+              ["get", "FCode"],
               [
                 42800,
                 42801,


### PR DESCRIPTION
Fixed "fcode" to be "FCode" and now flow lines show up in web viewer, fixes issue #1000 . 