### PR TITLE
Both FCode and fcode are symbolized in flowlines now

### DIFF
--- a/Symbology/web/Shared/flow_lines.json
+++ b/Symbology/web/Shared/flow_lines.json
@@ -31,6 +31,26 @@
       }
   },
   {
+      "id": "Full NHD HR - solid (lowercase)",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "NHD_flowline-6tver9",
+      "layout": {},
+      "paint": {
+          "line-color": [
+              "match",
+              ["get", "fcode"],
+              [46006],
+              "hsl(213, 100%, 33%)",
+              [33400],
+              "hsl(40, 100%, 50%)",
+              [55800],
+              "hsl(351, 55%, 58%)",
+              "hsla(0, 0%, 0%, 0)"
+          ]
+      }
+  },
+  {
       "id": "Full NHD HR - dashed",
       "type": "line",
       "source": "composite",
@@ -40,6 +60,27 @@
           "line-color": [
               "match",
               ["get", "FCode"],
+              [46003],
+              "hsl(80, 100%, 50%)",
+              [46007],
+              "hsl(40, 100%, 45%)",
+              [33600, 33601, 33603],
+              "hsl(194, 100%, 72.55%)",
+              "hsla(0, 0%, 0%, 0)"
+          ],
+          "line-dasharray": [1, 2]
+      }
+  },
+  {
+      "id": "Full NHD HR - dashed (lowercase)",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "NHD_flowline-6tver9",
+      "layout": {},
+      "paint": {
+          "line-color": [
+              "match",
+              ["get", "fcode"],
               [46003],
               "hsl(80, 100%, 50%)",
               [46007],
@@ -88,6 +129,42 @@
       }
   },
   {
+      "id": "Full NHD HR - pipes (lowercase)",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "NHD_flowline-6tver9",
+      "layout": {},
+      "paint": {
+          "line-dasharray": [2, 2],
+          "line-color": [
+              "match",
+              ["get", "fcode"],
+              [
+                42800,
+                42801,
+                42802,
+                42803,
+                42804,
+                42805,
+                42806,
+                42807,
+                42808,
+                42809,
+                42810,
+                42811,
+                42812,
+                42813,
+                42814,
+                42815,
+                42816
+                ],
+              "#000000",
+              "hsla(0, 0%, 0%, 0)"
+          ],
+          "line-width": 2
+      }
+  },
+  {
       "id": "Full NHD HR - pipes gap",
       "type": "line",
       "source": "composite",
@@ -97,6 +174,42 @@
           "line-color": [
               "match",
               ["get", "FCode"],
+              [
+                42800,
+                42801,
+                42802,
+                42803,
+                42804,
+                42805,
+                42806,
+                42807,
+                42808,
+                42809,
+                42810,
+                42811,
+                42812,
+                42813,
+                42814,
+                42815,
+                42816
+                ],
+              "#000000",
+              "hsla(0, 0%, 0%, 0)"
+          ],
+          "line-width": 2,
+          "line-gap-width": 2
+      }
+  },
+  {
+      "id": "Full NHD HR - pipes gap (lowercase)",
+      "type": "line",
+      "source": "composite",
+      "source-layer": "NHD_flowline-6tver9",
+      "layout": {},
+      "paint": {
+          "line-color": [
+              "match",
+              ["get", "fcode"],
               [
                 42800,
                 42801,


### PR DESCRIPTION
Updated web flowlines symbology so that both FCode and fcode can be symbolized with the same file. QGIS and ArcPro symbology are case-insensitive so only the web file needed the capitalization flexibility. 